### PR TITLE
:sparkles: Implement binary writing of rom header and banner

### DIFF
--- a/src/Ekona/Containers/Rom/Banner2Binary.cs
+++ b/src/Ekona/Containers/Rom/Banner2Binary.cs
@@ -1,0 +1,161 @@
+﻿// Copyright(c) 2022 SceneGate
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using System;
+using System.Text;
+using Texim.Colors;
+using Texim.Images;
+using Texim.Pixels;
+using Yarhl.FileFormat;
+using Yarhl.FileSystem;
+using Yarhl.IO;
+
+namespace SceneGate.Ekona.Containers.Rom;
+
+/// <summary>
+/// Convert a container with banner information into a binary stream.
+/// </summary>
+/// <remarks>
+/// <para>Supported versions: 0.1, 0.2, 0.3 and 1.3 (except animated icons).</para>
+/// <para>The input container expects to have:</para>
+/// <list type="table">
+/// <item><term>/info</term><description>Program banner content with Banner format.</description></item>
+/// <item><term>/icon</term><description>Program icon with IndexedPaletteImage format.</description></item>
+/// </list>
+/// </remarks>
+public class Banner2Binary : IConverter<NodeContainerFormat, BinaryFormat>
+{
+    /// <summary>
+    /// Write a container banner into a binary format.
+    /// </summary>
+    /// <param name="source">Banner to serialize into binary format.</param>
+    /// <returns>The new serialized binary.</returns>
+    public BinaryFormat Convert(NodeContainerFormat source)
+    {
+        if (source is null)
+            throw new ArgumentNullException(nameof(source));
+
+        Banner banner = GetFormatSafe<Banner>(source.Root, "info");
+        IndexedPaletteImage icon = GetFormatSafe<IndexedPaletteImage>(source.Root, "icon");
+
+        var binary = new BinaryFormat();
+        var writer = new DataWriter(binary.Stream) {
+            DefaultEncoding = Encoding.Unicode,
+        };
+
+        // Write empty header, as we need the data to generate checksum
+        writer.WriteTimes(0, 0x20);
+
+        WriteIcon(writer, icon);
+        WriteTitles(writer, banner);
+
+        if (banner.Version.Major > 0) {
+            WriteAnimatedIcon(writer);
+        }
+
+        writer.Stream.Position = 0;
+        WriteHeader(writer, banner);
+
+        return binary;
+    }
+
+    private static T GetFormatSafe<T>(Node root, string childName)
+        where T : class, IFormat
+    {
+        Node child = root.Children[childName] ?? throw new FormatException($"Missing child '{childName}'");
+        return child.GetFormatAs<T>()
+            ?? throw new FormatException($"Child '{childName}' has not the expected format: {typeof(T).Name}");
+    }
+
+    private static void WriteHeader(DataWriter writer, Banner banner)
+    {
+        writer.Write((byte)banner.Version.Minor);
+        writer.Write((byte)banner.Version.Major);
+
+        writer.WriteComputedCrc16(0x20, 0x820);
+
+        if (banner.Version.Minor > 1) {
+            writer.WriteComputedCrc16(0x20, 0x920);
+        } else {
+            writer.Write((ushort)0x00);
+        }
+
+        if (banner.Version.Minor > 2) {
+            writer.WriteComputedCrc16(0x20, 0xA20);
+        } else {
+            writer.Write((ushort)0x00);
+        }
+
+        if (banner.Version.Major > 0) {
+            writer.WriteComputedCrc16(0x1240, 0x1180);
+        } else {
+            writer.Write((ushort)0x00);
+        }
+
+        writer.WriteTimes(0, 0x16); // reserved
+    }
+
+    private static void WriteIcon(DataWriter writer, IndexedPaletteImage icon)
+    {
+        var swizzling = new TileSwizzling<IndexedPixel>(icon.Width);
+        var pixels = swizzling.Swizzle(icon.Pixels);
+        writer.Write<Indexed4Bpp>(pixels);
+
+        if (icon.Palettes.Count != 1) {
+            throw new FormatException("Invalid number of palettes for icon, expected 1");
+        }
+
+        writer.Write<Bgr555>(icon.Palettes[0].Colors);
+    }
+
+    private static void WriteTitles(DataWriter writer, Banner banner)
+    {
+        writer.Write(banner.JapaneseTitle, 0x100);
+        writer.Write(banner.EnglishTitle, 0x100);
+        writer.Write(banner.FrenchTitle, 0x100);
+        writer.Write(banner.GermanTitle, 0x100);
+        writer.Write(banner.ItalianTitle, 0x100);
+        writer.Write(banner.SpanishTitle, 0x100);
+
+        if (banner.Version.Minor > 1) {
+            writer.Write(banner.ChineseTitle, 0x100);
+        } else {
+            writer.WriteTimes(0xFF, 0x100);
+        }
+
+        if (banner.Version.Minor > 2) {
+            writer.Write(banner.KoreanTitle, 0x100);
+        } else {
+            writer.WriteTimes(0xFF, 0xC0);
+            writer.WriteTimes(0x00, 0x40);
+        }
+
+        // reserved for future titles
+        writer.WriteTimes(0, 0x800);
+    }
+
+    private static void WriteAnimatedIcon(DataWriter writer)
+    {
+        // TODO: implement properly
+        writer.WriteTimes(0, 0x1000); // 8 bitmaps
+        writer.WriteTimes(0, 0x100); // 8 palettes
+        writer.WriteTimes(0, 0x80); // animation sequence
+        writer.WriteTimes(0xFF, 0x40); // padding
+    }
+}

--- a/src/Ekona/Containers/Rom/Binary2Banner.cs
+++ b/src/Ekona/Containers/Rom/Binary2Banner.cs
@@ -78,6 +78,7 @@ namespace SceneGate.Ekona.Containers.Rom
         /// <returns>The new container with the banner.</returns>
         public NodeContainerFormat Convert(IBinary source)
         {
+            source.Stream.Position = 0;
             var reader = new DataReader(source.Stream) {
                 DefaultEncoding = Encoding.Unicode,
             };

--- a/src/Ekona/Containers/Rom/Binary2RomHeader.cs
+++ b/src/Ekona/Containers/Rom/Binary2RomHeader.cs
@@ -83,8 +83,9 @@ namespace SceneGate.Ekona.Containers.Rom
             header.ProgramInfo.SecureDisable = reader.ReadUInt64();
             header.SectionInfo.RomSize = reader.ReadUInt32();
             header.SectionInfo.HeaderSize = reader.ReadUInt32();
+            header.SectionInfo.Unknown88 = reader.ReadUInt32();
 
-            source.Stream.Position += 0x38;
+            source.Stream.Position += 0x34;
             header.CopyrightLogo = reader.ReadBytes(156);
             header.ProgramInfo.ChecksumLogo = reader.ValidateCrc16(0xC0, 0x9C);
             header.ProgramInfo.ChecksumHeader = reader.ValidateCrc16(0x00, 0x15E);

--- a/src/Ekona/Containers/Rom/RomHeader2Binary.cs
+++ b/src/Ekona/Containers/Rom/RomHeader2Binary.cs
@@ -1,0 +1,102 @@
+﻿// Copyright(c) 2021 SceneGate
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using System;
+using Yarhl.FileFormat;
+using Yarhl.IO;
+
+namespace SceneGate.Ekona.Containers.Rom;
+
+/// <summary>
+/// Converter for ROM header object into binary stream (serialization).
+/// </summary>
+public class RomHeader2Binary : IConverter<RomHeader, BinaryFormat>
+{
+    /// <summary>
+    /// Serialize a ROM header object into a binary stream.
+    /// </summary>
+    /// <param name="source">The header to convert.</param>
+    /// <returns>The new binary stream.</returns>
+    /// <exception cref="ArgumentNullException">The argument is null.</exception>
+    public BinaryFormat Convert(RomHeader source)
+    {
+        if (source is null)
+            throw new ArgumentNullException(nameof(source));
+
+        var binary = new BinaryFormat();
+        var writer = new DataWriter(binary.Stream);
+
+        writer.Write(source.ProgramInfo.GameTitle, 12, nullTerminator: false);
+        writer.Write(source.ProgramInfo.GameCode, 4, nullTerminator: false);
+        writer.Write(source.ProgramInfo.MakerCode, 2, nullTerminator: false);
+        writer.Write(source.ProgramInfo.UnitCode);
+        writer.Write(source.ProgramInfo.EncryptionSeed);
+        double relativeSize = (double)source.ProgramInfo.CartridgeSize / RomInfo.MinimumCartridgeSize;
+        byte power2Size = (byte)Math.Ceiling(Math.Log2(relativeSize));
+        writer.Write(power2Size);
+
+        writer.WriteTimes(0, 7); // reserved
+        writer.Write(source.ProgramInfo.DsiFlags);
+        writer.Write(source.ProgramInfo.Region);
+        writer.Write(source.ProgramInfo.Version);
+        writer.Write(source.ProgramInfo.AutoStartFlag);
+
+        writer.Write(source.SectionInfo.Arm9Offset);
+        writer.Write(source.ProgramInfo.Arm9EntryAddress);
+        writer.Write(source.ProgramInfo.Arm9RamAddress);
+        writer.Write(source.SectionInfo.Arm9Size);
+        writer.Write(source.SectionInfo.Arm7Offset);
+        writer.Write(source.ProgramInfo.Arm7EntryAddress);
+        writer.Write(source.ProgramInfo.Arm7RamAddress);
+        writer.Write(source.SectionInfo.Arm7Size);
+        writer.Write(source.SectionInfo.FntOffset);
+        writer.Write(source.SectionInfo.FntSize);
+        writer.Write(source.SectionInfo.FatOffset);
+        writer.Write(source.SectionInfo.FatSize);
+        writer.Write(source.SectionInfo.Overlay9TableOffset);
+        writer.Write(source.SectionInfo.Overlay9TableSize);
+        writer.Write(source.SectionInfo.Overlay7TableOffset);
+        writer.Write(source.SectionInfo.Overlay7TableSize);
+
+        writer.Write(source.ProgramInfo.FlagsRead);
+        writer.Write(source.ProgramInfo.FlagsInit);
+        writer.Write(source.SectionInfo.BannerOffset);
+        writer.Write(source.ProgramInfo.ChecksumSecureArea.Expected);
+        writer.Write(source.ProgramInfo.SecureAreaDelay);
+        writer.Write(source.ProgramInfo.Arm9Autoload);
+        writer.Write(source.ProgramInfo.Arm7Autoload);
+        writer.Write(source.ProgramInfo.SecureDisable);
+        writer.Write(source.SectionInfo.RomSize);
+        writer.Write(source.SectionInfo.HeaderSize);
+        writer.Write(source.SectionInfo.Unknown88);
+
+        writer.WriteTimes(0, 0x34);
+        writer.Write(source.CopyrightLogo);
+        writer.Write(source.ProgramInfo.ChecksumLogo.Expected);
+        writer.Write(source.ProgramInfo.ChecksumHeader.Expected);
+
+        writer.Write(source.ProgramInfo.DebugRomOffset);
+        writer.Write(source.ProgramInfo.DebugSize);
+        writer.Write(source.ProgramInfo.DebugRamAddress);
+
+        writer.WriteUntilLength(0, source.SectionInfo.HeaderSize);
+
+        return binary;
+    }
+}

--- a/src/Ekona/Containers/Rom/RomSectionInfo.cs
+++ b/src/Ekona/Containers/Rom/RomSectionInfo.cs
@@ -98,5 +98,14 @@ namespace SceneGate.Ekona.Containers.Rom
         /// Gets or sets the size of the header.
         /// </summary>
         public uint HeaderSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets an unknown value at 0x88.
+        /// </summary>
+        /// <remarks>
+        /// In DS games it looks like an offset pointing to the SDK information
+        /// inside the arm9.bin.
+        /// </remarks>
+        public uint Unknown88 { get; set; }
     }
 }

--- a/src/Ekona/InternalExtensions.cs
+++ b/src/Ekona/InternalExtensions.cs
@@ -30,5 +30,22 @@ namespace SceneGate.Ekona
                 Actual = actual,
             };
         }
+
+        /// <summary>
+        /// Compute a CRC16 over the specific substream and write the result.
+        /// </summary>
+        /// <param name="writer">Write to write the result and get the stream.</param>
+        /// <param name="offset">Offset of the segment to calculate the CRC.</param>
+        /// <param name="length">The length to calculate the CRC.</param>
+        public static void WriteComputedCrc16(this DataWriter writer, long offset, long length)
+        {
+            using DataStream segment = new DataStream(writer.Stream, offset, length);
+
+            ICRC crc = CRCFactory.Instance.Create(CRCConfig.MODBUS);
+            IHashValue hash = crc.ComputeHash(segment);
+            ushort actual = (ushort)(hash.Hash[0] | (hash.Hash[1] << 8));
+
+            writer.Write(actual);
+        }
     }
 }


### PR DESCRIPTION
### Description

- Implement writing of `RomHeader` into binary format (except DSi flags).
- Implement writing of `Node` containing `Banner` and the icon into binary format (except animated DSi icons).

### Example

Use the new converters `RomHeader2Binary` and `Banner2Binary`.

This closes #5, #6