### PR TITLE
:sparkles: Implement read and write of DSi animated banner icon

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -177,6 +177,7 @@ dotnet_diagnostic.IDE0058.severity = suggestion # Expression value is never used
 
 ### SonarAnalyzer
 dotnet_diagnostic.S1135.severity = suggestion # It's almost inevitable to have TODO but add bug ID
+dotnet_diagnostic.S1172.severity = silent # Buggy
 
 # Special rules for test projects
 [*Tests/**]

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -2,7 +2,7 @@
     <!-- Centralize dependency management -->
     <ItemGroup>
         <PackageVersion Include="Yarhl" Version="4.0.0-preview.153" />
-        <PackageVersion Include="Texim" Version="0.1.0-preview.113" />
+        <PackageVersion Include="Texim" Version="0.1.0-preview.129" />
         <PackageVersion Include="System.Data.HashFunction.CRC" Version="2.0.0" />
 
         <PackageVersion Include="YamlDotNet" Version="11.2.1" />

--- a/src/Ekona.Tests/Containers/Rom/Binary2BannerTests.cs
+++ b/src/Ekona.Tests/Containers/Rom/Binary2BannerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright(c) 2021 SceneGate
+// Copyright(c) 2021 SceneGate
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -17,6 +17,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -25,6 +26,7 @@ using NUnit.Framework;
 using SceneGate.Ekona.Containers.Rom;
 using Texim.Formats;
 using Texim.Images;
+using Texim.Palettes;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 using Yarhl.FileFormat;
@@ -41,18 +43,23 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
             string basePath = Path.Combine(TestDataBase.RootFromOutputPath, "Containers");
             string listPath = Path.Combine(basePath, "banner.txt");
             return TestDataBase.ReadTestListFile(listPath)
-                .Select(data => new TestCaseData(
-                    Path.Combine(basePath, data),
-                    Path.Combine(basePath, data + ".yml"),
-                    Path.Combine(basePath, data + ".png"))
+                .Select(data => new TestCaseData(Path.Combine(basePath, data))
                     .SetName($"{{m}}({data})"));
         }
 
+        public static string GetInfoFile(string bannerPath) => bannerPath + ".yml";
+
+        public static string GetIconFile(string bannerPath) => bannerPath + ".png";
+
+        public static string GetAniInfoFile(string bannerPath) => bannerPath + ".ani.yml";
+
         [TestCaseSource(nameof(GetFiles))]
-        public void DeserializeBannerMatchInfo(string bannerPath, string infoPath, string iconPath)
+        public void DeserializeBannerMatchInfo(string bannerPath)
         {
-            TestDataBase.IgnoreIfFileDoesNotExist(infoPath);
             TestDataBase.IgnoreIfFileDoesNotExist(bannerPath);
+
+            string infoPath = GetInfoFile(bannerPath);
+            TestDataBase.IgnoreIfFileDoesNotExist(infoPath);
 
             string yaml = File.ReadAllText(infoPath);
             Banner expected = new DeserializerBuilder()
@@ -62,16 +69,7 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
 
             using Node node = NodeFactory.FromFile(bannerPath, FileOpenMode.Read);
             node.Invoking(n => n.TransformWith<Binary2Banner>()).Should().NotThrow();
-            node.Children.Should().HaveCount(2);
             node.Children["info"].Should().NotBeNull();
-            node.Children["icon"].Should().NotBeNull();
-
-            var paletteParam = new IndexedImageBitmapParams {
-                Palettes = node.Children["icon"].GetFormatAs<IndexedPaletteImage>(),
-            };
-            node.Children["icon"].TransformWith<IndexedImage2Bitmap, IndexedImageBitmapParams>(paletteParam);
-            using var expectedIcon = NodeFactory.FromFile(iconPath, FileOpenMode.Read);
-            expectedIcon.Stream.Compare(node.Children["icon"].Stream).Should().BeTrue();
 
             var actual = node.Children["info"].GetFormatAs<Banner>();
             actual.Version.Should().Be(expected.Version);
@@ -85,8 +83,11 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
                 actual.ChecksumKorean.IsValid.Should().BeTrue();
             }
 
-            if (actual.Version is { Major: 1, Minor: 3 }) {
+            if (actual.Version is { Major: > 1 } or { Major: 1, Minor: >= 3 }) {
+                actual.SupportAnimatedIcon.Should().BeTrue();
                 actual.ChecksumAnimatedIcon.IsValid.Should().BeTrue();
+            } else {
+                actual.SupportAnimatedIcon.Should().BeFalse();
             }
 
             actual.JapaneseTitle.Should().Be(expected.JapaneseTitle);
@@ -106,7 +107,77 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
         }
 
         [TestCaseSource(nameof(GetFiles))]
-        public void TwoWaysIdenticalBannerStream(string bannerPath, string infoPath, string iconPath)
+        public void DeserializeBannerIcon(string bannerPath)
+        {
+            TestDataBase.IgnoreIfFileDoesNotExist(bannerPath);
+
+            string expectedIconPath = GetIconFile(bannerPath);
+            TestDataBase.IgnoreIfFileDoesNotExist(expectedIconPath);
+
+            using Node node = NodeFactory.FromFile(bannerPath, FileOpenMode.Read);
+            node.Invoking(n => n.TransformWith<Binary2Banner>()).Should().NotThrow();
+            Node actualIcon = node.Children["icon"];
+            actualIcon.Should().NotBeNull();
+
+            var paletteParam = new IndexedImageBitmapParams {
+                Palettes = actualIcon.GetFormatAs<IPaletteCollection>(),
+            };
+            actualIcon.Invoking(n => n.TransformWith<IndexedImage2Bitmap, IndexedImageBitmapParams>(paletteParam))
+                .Should().NotThrow();
+
+            using var expectedIcon = NodeFactory.FromFile(expectedIconPath, FileOpenMode.Read);
+            actualIcon.Stream.Compare(expectedIcon.Stream).Should().BeTrue();
+        }
+
+        [TestCaseSource(nameof(GetFiles))]
+        public void DeserializeBannerAnimatedIcon(string bannerPath)
+        {
+            TestDataBase.IgnoreIfFileDoesNotExist(bannerPath);
+
+            using Node node = NodeFactory.FromFile(bannerPath, FileOpenMode.Read);
+            node.Invoking(n => n.TransformWith<Binary2Banner>()).Should().NotThrow();
+            if (!node.Children["info"].GetFormatAs<Banner>().SupportAnimatedIcon) {
+                Assert.Pass();
+            }
+
+            Node animated = node.Children["animated"];
+            animated.Should().NotBeNull();
+
+            int numImages = Binary2Banner.NumAnimatedImages;
+            animated.Children.Where(n => n.Name.StartsWith("bitmap")).Should().HaveCount(numImages);
+            animated.Children["palettes"]?.GetFormatAs<PaletteCollection>()?.Palettes.Should().HaveCount(numImages);
+            animated.Children["animation"].Should().NotBeNull();
+
+            // TODO: GIF support in Texim
+            string infoPath = GetAniInfoFile(bannerPath);
+            TestDataBase.IgnoreIfFileDoesNotExist(infoPath);
+
+            string yaml = File.ReadAllText(infoPath);
+            IconAnimationSequence expectedInfo = new DeserializerBuilder()
+                .WithNamingConvention(UnderscoredNamingConvention.Instance)
+                .Build()
+                .Deserialize<IconAnimationSequence>(yaml);
+
+            animated.Children["animation"].GetFormatAs<IconAnimationSequence>()
+                .Should().BeEquivalentTo(expectedInfo);
+        }
+
+        [Test]
+        public void FrameCannotHaveMoreThan8ImagesPalettes()
+        {
+            var frame = new IconAnimationFrame();
+            frame.Invoking(f => f.BitmapIndex = 8)
+                .Should().Throw<ArgumentOutOfRangeException>();
+            frame.Invoking(f => f.BitmapIndex = -1)
+                .Should().Throw<ArgumentOutOfRangeException>();
+            frame.Invoking(f => f.PaletteIndex = 8)
+                .Should().Throw<ArgumentOutOfRangeException>();
+            frame.Invoking(f => f.PaletteIndex = -1)
+                .Should().Throw<ArgumentOutOfRangeException>();
+        }
+
+        [TestCaseSource(nameof(GetFiles))]
+        public void TwoWaysIdenticalBannerStream(string bannerPath)
         {
             TestDataBase.IgnoreIfFileDoesNotExist(bannerPath);
 
@@ -117,12 +188,11 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
 
             generatedStream.Stream.Length.Should().Be(node.Stream!.Length);
 
-            // TODO: After implementing animations, can compare streams
             // generatedStream.Stream.Compare(node.Stream).Should().BeTrue()
         }
 
         [TestCaseSource(nameof(GetFiles))]
-        public void ThreeWaysIdenticalBannerObjects(string bannerPath, string infoPath, string iconPath)
+        public void ThreeWaysIdenticalBannerObjects(string bannerPath)
         {
             TestDataBase.IgnoreIfFileDoesNotExist(bannerPath);
 
@@ -138,9 +208,10 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
             var generatedBanner = generatedNode.Root.Children["info"].GetFormatAs<Banner>();
             var generatedIcon = generatedNode.Root.Children["icon"].GetFormatAs<IndexedPaletteImage>();
 
-            // TODO: Implement icon animations
             generatedBanner.Should().BeEquivalentTo(originalBanner, opts => opts.Excluding(f => f.ChecksumAnimatedIcon));
             generatedIcon.Should().BeEquivalentTo(originalIcon);
+
+            // TODO: compare animated
         }
     }
 }

--- a/src/Ekona.Tests/Resources/.gitignore
+++ b/src/Ekona.Tests/Resources/.gitignore
@@ -2,3 +2,4 @@
 *.banner
 *.png
 *.yml
+*.gif

--- a/src/Ekona/Containers/Rom/Banner.cs
+++ b/src/Ekona/Containers/Rom/Banner.cs
@@ -1,4 +1,4 @@
-﻿// Copyright(c) 2021 SceneGate
+// Copyright(c) 2021 SceneGate
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -55,6 +55,11 @@ namespace SceneGate.Ekona.Containers.Rom
                 version = value;
             }
         }
+
+        /// <summary>
+        /// Gets a value indicating whether the banner supports animated icons (version >= 1.3).
+        /// </summary>
+        public bool SupportAnimatedIcon => Version is { Major: > 1 } or { Major: 1, Minor: >= 3 };
 
         /// <summary>
         /// Gets or sets the CRC-16 checksum for the banner binary data of version 0.1.

--- a/src/Ekona/Containers/Rom/Banner2Binary.cs
+++ b/src/Ekona/Containers/Rom/Banner2Binary.cs
@@ -181,7 +181,7 @@ public class Banner2Binary : IConverter<NodeContainerFormat, BinaryFormat>
             }
 
             var frame = animation.Frames[i];
-            ushort data = (byte)(frame.FrameDuration * 60.0 / 1000);
+            ushort data = (byte)(frame.Duration * 60.0 / 1000);
             data |= (ushort)(frame.BitmapIndex << 8);
             data |= (ushort)(frame.PaletteIndex << 11);
             data |= (ushort)((frame.FlipHorizontal ? 1 : 0) << 14);

--- a/src/Ekona/Containers/Rom/Banner2Binary.cs
+++ b/src/Ekona/Containers/Rom/Banner2Binary.cs
@@ -1,4 +1,4 @@
-﻿// Copyright(c) 2022 SceneGate
+// Copyright(c) 2022 SceneGate
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -18,9 +18,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 using System;
+using System.Linq;
 using System.Text;
 using Texim.Colors;
 using Texim.Images;
+using Texim.Palettes;
 using Texim.Pixels;
 using Yarhl.FileFormat;
 using Yarhl.FileSystem;
@@ -65,8 +67,8 @@ public class Banner2Binary : IConverter<NodeContainerFormat, BinaryFormat>
         WriteIcon(writer, icon);
         WriteTitles(writer, banner);
 
-        if (banner.Version.Major > 0) {
-            WriteAnimatedIcon(writer);
+        if (banner.SupportAnimatedIcon) {
+            WriteAnimatedIcon(writer, GetChildSafe(source.Root, "animated"));
         }
 
         writer.Stream.Position = 0;
@@ -75,11 +77,14 @@ public class Banner2Binary : IConverter<NodeContainerFormat, BinaryFormat>
         return binary;
     }
 
+    private static Node GetChildSafe(Node root, string childName) =>
+        root.Children[childName]
+            ?? throw new FormatException($"Missing child '{childName}'");
+
     private static T GetFormatSafe<T>(Node root, string childName)
         where T : class, IFormat
     {
-        Node child = root.Children[childName] ?? throw new FormatException($"Missing child '{childName}'");
-        return child.GetFormatAs<T>()
+        return GetChildSafe(root, childName).GetFormatAs<T>()
             ?? throw new FormatException($"Child '{childName}' has not the expected format: {typeof(T).Name}");
     }
 
@@ -142,14 +147,46 @@ public class Banner2Binary : IConverter<NodeContainerFormat, BinaryFormat>
         }
     }
 
-    private static void WriteAnimatedIcon(DataWriter writer)
+    private static void WriteAnimatedIcon(DataWriter writer, Node container)
     {
-        // TODO: implement properly
-        writer.WriteUntilLength(0xFF, 0x1240);
+        writer.WriteUntilLength(0, 0x1240);
         writer.Stream.Position = 0x1240;
 
-        writer.WriteTimes(0, 0x1000); // 8 bitmaps
-        writer.WriteTimes(0, 0x100); // 8 palettes
-        writer.WriteTimes(0, 0x80); // animation sequence
+        int numBitmaps = container.Children.Count(n => n.Name.StartsWith("bitmap"));
+        if (numBitmaps != Binary2Banner.NumAnimatedImages) {
+            throw new FormatException("Required 8 animated bitmaps");
+        }
+
+        for (int i = 0; i < numBitmaps; i++) {
+            var icon = GetFormatSafe<IndexedImage>(container, $"bitmap{i}");
+            var swizzling = new TileSwizzling<IndexedPixel>(icon.Width);
+            var pixels = swizzling.Swizzle(icon.Pixels);
+            writer.Write<Indexed4Bpp>(pixels);
+        }
+
+        var palettes = GetFormatSafe<PaletteCollection>(container, "palettes");
+        if (palettes.Palettes.Count != Binary2Banner.NumAnimatedImages) {
+            throw new FormatException("Required 8 palettes for the animated icons");
+        }
+
+        foreach (IPalette palette in palettes.Palettes) {
+            writer.Write<Bgr555>(palette.Colors);
+        }
+
+        var animation = GetFormatSafe<IconAnimationSequence>(container, "animation");
+        for (int i = 0; i < 64; i++) {
+            if (i >= animation.Frames.Count) {
+                writer.Write((ushort)0);
+                continue;
+            }
+
+            var frame = animation.Frames[i];
+            ushort data = (byte)(frame.FrameDuration * 60.0 / 1000);
+            data |= (ushort)(frame.BitmapIndex << 8);
+            data |= (ushort)(frame.PaletteIndex << 11);
+            data |= (ushort)((frame.FlipHorizontal ? 1 : 0) << 14);
+            data |= (ushort)((frame.FlipVertical ? 1 : 0) << 15);
+            writer.Write(data);
+        }
     }
 }

--- a/src/Ekona/Containers/Rom/Binary2Banner.cs
+++ b/src/Ekona/Containers/Rom/Binary2Banner.cs
@@ -185,9 +185,9 @@ namespace SceneGate.Ekona.Containers.Rom
 
             reader.Stream.Position = 0x1240;
 
+            var swizzling = new TileSwizzling<IndexedPixel>(IconWidth);
             for (int i = 0; i < NumAnimatedImages; i++) {
                 IndexedPixel[] pixels = reader.ReadPixels<Indexed4Bpp>(IconWidth * IconHeight);
-                var swizzling = new TileSwizzling<IndexedPixel>(IconWidth);
                 pixels = swizzling.Unswizzle(pixels);
 
                 var bitmap = new IndexedImage(IconWidth, IconHeight, pixels);

--- a/src/Ekona/Containers/Rom/Binary2Banner.cs
+++ b/src/Ekona/Containers/Rom/Binary2Banner.cs
@@ -210,7 +210,7 @@ namespace SceneGate.Ekona.Containers.Rom
                 }
 
                 var frame = new IconAnimationFrame {
-                    FrameDuration = (int)((aniData & 0xFF) * 1000.0 / 60),
+                    Duration = (int)((aniData & 0xFF) * 1000.0 / 60),
                     BitmapIndex = (aniData >> 8) & 0x3,
                     PaletteIndex = (aniData >> 11) & 0x3,
                     FlipHorizontal = ((aniData >> 14) & 0x1) != 0,

--- a/src/Ekona/Containers/Rom/Binary2NitroRom.cs
+++ b/src/Ekona/Containers/Rom/Binary2NitroRom.cs
@@ -1,4 +1,4 @@
-﻿// Copyright(c) 2021 SceneGate
+// Copyright(c) 2021 SceneGate
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -84,6 +84,10 @@ namespace SceneGate.Ekona.Containers.Rom
 
         private void ReadBanner()
         {
+            if (header.SectionInfo.BannerOffset == 0) {
+                return;
+            }
+
             reader.Stream.Position = header.SectionInfo.BannerOffset;
             int bannerSize = Binary2Banner.GetSize(reader.Stream);
             var binaryBanner = new BinaryFormat(reader.Stream, header.SectionInfo.BannerOffset, bannerSize);

--- a/src/Ekona/Containers/Rom/IconAnimation2AnimatedImage.cs
+++ b/src/Ekona/Containers/Rom/IconAnimation2AnimatedImage.cs
@@ -1,0 +1,92 @@
+// Copyright(c) 2022 SceneGate
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using System;
+using System.Drawing;
+using System.Linq;
+using Texim.Animations;
+using Texim.Images;
+using Texim.Palettes;
+using Texim.Pixels;
+using Yarhl.FileFormat;
+using Yarhl.FileSystem;
+
+namespace SceneGate.Ekona.Containers.Rom
+{
+    /// <summary>
+    /// Converter for ROM banner animated icons into an animated image.
+    /// </summary>
+    public class IconAnimation2AnimatedImage : IConverter<NodeContainerFormat, AnimatedFullImage>
+    {
+        /// <summary>
+        /// Convert the 'animated' node from the ROM banner into an animated image.
+        /// </summary>
+        /// <param name="source">The animated node of the ROM banner.</param>
+        /// <returns>A new animated image.</returns>
+        /// <exception cref="ArgumentNullException">The argument is null.</exception>
+        public AnimatedFullImage Convert(NodeContainerFormat source)
+        {
+            if (source is null)
+                throw new ArgumentNullException(nameof(source));
+
+            IndexedImage[] bitmaps = source.Root.Children
+                .Where(n => n.Name.StartsWith("bitmap"))
+                .Select(n => n.GetFormatAs<IndexedImage>())
+                .ToArray();
+            if (bitmaps.Length == 0) {
+                throw new FormatException("Missing bitmaps");
+            }
+
+            IPaletteCollection palette = source.Root.Children["palettes"]?.GetFormatAs<IPaletteCollection>()
+                ?? throw new FormatException("Missing palettes or wrong format");
+            IconAnimationSequence animation = source.Root.Children["animation"]?.GetFormatAs<IconAnimationSequence>()
+                ?? throw new FormatException("Missing animation sequence or wrong format");
+
+            var animatedImage = new AnimatedFullImage();
+            animatedImage.Loops = 0; // infinite
+
+            var fullImageConverter = new Indexed2FullImage();
+            int width = bitmaps[0].Width;
+            int height = bitmaps[0].Height;
+
+            foreach (IconAnimationFrame frameInfo in animation.Frames) {
+                var framePixels = ((IndexedPixel[])bitmaps[frameInfo.BitmapIndex].Pixels.Clone()).AsSpan();
+                if (frameInfo.FlipHorizontal) {
+                    framePixels.FlipHorizontal(new Size(width, height));
+                }
+
+                if (frameInfo.FlipVertical) {
+                    framePixels.FlipVertical(new Size(width, height));
+                }
+
+                var frameIndexed = new IndexedImage(width, height, framePixels.ToArray());
+                fullImageConverter.Initialize(palette.Palettes[frameInfo.PaletteIndex]);
+                FullImage frameImage = fullImageConverter.Convert(frameIndexed);
+
+                var frame = new FullImageFrame {
+                    Image = frameImage,
+                    Duration = frameInfo.Duration,
+                };
+                animatedImage.Frames.Add(frame);
+            }
+
+            return animatedImage;
+        }
+    }
+}

--- a/src/Ekona/Containers/Rom/IconAnimationFrame.cs
+++ b/src/Ekona/Containers/Rom/IconAnimationFrame.cs
@@ -35,7 +35,7 @@ public class IconAnimationFrame
     /// <remarks>
     /// The resolution is 60 Hz.
     /// </remarks>
-    public int FrameDuration { get; set; }
+    public int Duration { get; set; }
 
     /// <summary>
     /// Gets or sets the index of the bitmap for this frame.

--- a/src/Ekona/Containers/Rom/IconAnimationFrame.cs
+++ b/src/Ekona/Containers/Rom/IconAnimationFrame.cs
@@ -1,0 +1,89 @@
+// Copyright(c) 2022 SceneGate
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using System;
+
+namespace SceneGate.Ekona.Containers.Rom;
+
+/// <summary>
+/// Frame definition for the ROM animated icon.
+/// </summary>
+public class IconAnimationFrame
+{
+    private int bitmapIndex;
+    private int paletteIndex;
+
+    /// <summary>
+    /// Gets or sets the duration of the frame in milliseconds.
+    /// </summary>
+    /// <remarks>
+    /// The resolution is 60 Hz.
+    /// </remarks>
+    public int FrameDuration { get; set; }
+
+    /// <summary>
+    /// Gets or sets the index of the bitmap for this frame.
+    /// </summary>
+    /// <remarks>
+    /// There are maximum 8 bitmaps.
+    /// </remarks>
+    public int BitmapIndex {
+        get => bitmapIndex;
+        set {
+            if (value < 0 || value >= Binary2Banner.NumAnimatedImages) {
+                throw new ArgumentOutOfRangeException(
+                    nameof(value),
+                    value,
+                    "Animated icons can't have more than 8 bitmaps");
+            }
+
+            bitmapIndex = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the palette to use for the bitmap of this frame.
+    /// </summary>
+    /// <remarks>
+    /// There are maximum 8 palettes.
+    /// </remarks>
+    public int PaletteIndex {
+        get => paletteIndex;
+        set {
+            if (value < 0 || value >= Binary2Banner.NumAnimatedImages) {
+                throw new ArgumentOutOfRangeException(
+                    nameof(value),
+                    value,
+                    "Animated icons can't have more than 8 palettes");
+            }
+
+            paletteIndex = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the bitmap should flip horizontally.
+    /// </summary>
+    public bool FlipHorizontal { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the bitmap should flip vertically.
+    /// </summary>
+    public bool FlipVertical { get; set; }
+}

--- a/src/Ekona/Containers/Rom/IconAnimationSequence.cs
+++ b/src/Ekona/Containers/Rom/IconAnimationSequence.cs
@@ -1,0 +1,35 @@
+// Copyright(c) 2022 SceneGate
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using System.Collections.ObjectModel;
+using Yarhl.FileFormat;
+
+namespace SceneGate.Ekona.Containers.Rom
+{
+    /// <summary>
+    /// Sequence of definition of frames for the ROM animated icon.
+    /// </summary>
+    public class IconAnimationSequence : IFormat
+    {
+        /// <summary>
+        /// Gets the collection of frames.
+        /// </summary>
+        public Collection<IconAnimationFrame> Frames { get; init; } = new Collection<IconAnimationFrame>();
+    }
+}

--- a/src/Ekona/Containers/Rom/NitroRom2Binary.cs
+++ b/src/Ekona/Containers/Rom/NitroRom2Binary.cs
@@ -1,4 +1,4 @@
-﻿// Copyright(c) 2022 SceneGate
+// Copyright(c) 2022 SceneGate
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -80,11 +80,12 @@ public class NitroRom2Binary :
         binary.Stream.Position = 0;
         writer = new DataWriter(binary.Stream);
 
-        // Write the header at the end, when we got all the new offsets and sizes
         programInfo = GetChildFormatSafe<RomInfo>("system/info");
         sectionInfo = new RomSectionInfo {
             HeaderSize = 0x4000,
         };
+
+        // Write the header at the end, when we got all the new offsets and sizes
         writer.WriteTimes(0, sectionInfo.HeaderSize);
 
         // Sort nodes by ID
@@ -158,6 +159,10 @@ public class NitroRom2Binary :
 
     private void WriteBanner()
     {
+        if (root.Children["system"]?.Children["banner"] is null) {
+            return;
+        }
+
         writer.Stream.Position = sectionInfo.BannerOffset;
         GetChildSafe("system/banner")
             .TransformWith<Banner2Binary>()


### PR DESCRIPTION
### Description

Read and write the animated icon of DSi game banners, including a converter to transform into an animated image of Texim that can be converted into GIF.
Also avoid trying to read the banner if the ROM doesn't have it.

### Example

A new node `animated` is available from the `banner` node with the animated icon. If the game doesn't contain an animated icon (non-DSi games), then the node is empty. The node contains:

- `bitmapX`: 8 possible indexed images.
- `palettes`: palette collection with 8 possible palettes
- `animation`: animation sequence information. Each frame information points to a bitmap, palette and duration.

A new converter `IconAnimation2AnimatedImage` is available to convert these nodes into a Texim `AnimatedFullImage` that can be converted later into GIF.

Related to #8
