### PR TITLE
:sparkles: Read and write ARM9 code params and update ARM9 compressed length

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Ekona [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat)](https://choosealicense.com/licenses/mit/) ![Build and release](https://github.com/SceneGate/Ekona/workflows/Build%20and%20release/badge.svg)
 
-[Yarhl](https://github.com/SceneGate/yarhl) plugin for Nintendo DS common
-formats.
+[Yarhl](https://github.com/SceneGate/yarhl) plugin for DS common formats.
 
 The library supports .NET 6.0 and above on Linux, Window and MacOS.
 

--- a/src/Ekona.Tests/Containers/Rom/Binary2NitroRomTests.cs
+++ b/src/Ekona.Tests/Containers/Rom/Binary2NitroRomTests.cs
@@ -102,13 +102,15 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
 
             using Node node = NodeFactory.FromFile(romPath, FileOpenMode.Read);
 
-            var rom = (NodeContainerFormat)ConvertFormat.With<Binary2NitroRom>(node.Format!);
+            var rom = (NitroRom)ConvertFormat.With<Binary2NitroRom>(node.Format!);
             var generatedStream = (BinaryFormat)ConvertFormat.With<NitroRom2Binary>(rom);
 
             generatedStream.Stream.Length.Should().Be(node.Stream!.Length);
 
-            // TODO: After implementing ARM9 tail and DSi fields
-            // generatedStream.Stream!.Compare(node.Stream).Should().BeTrue()
+            // TODO: After implementing DSi fields
+            if (rom.Information.UnitCode == DeviceUnitKind.DS) {
+                generatedStream.Stream!.Compare(node.Stream).Should().BeTrue();
+            }
         }
 
         [TestCaseSource(nameof(GetFiles))]

--- a/src/Ekona.Tests/Containers/Rom/Binary2RomHeaderTests.cs
+++ b/src/Ekona.Tests/Containers/Rom/Binary2RomHeaderTests.cs
@@ -66,6 +66,7 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
                 expected,
                 opts => opts
                     .Excluding(p => p.CopyrightLogo)
+                    .Excluding((FluentAssertions.Equivalency.IMemberInfo info) => info.Type == typeof(NitroProgramCodeParameters))
                     .Excluding((FluentAssertions.Equivalency.IMemberInfo info) => info.Type == typeof(HashInfo)));
         }
 

--- a/src/Ekona/Containers/Rom/Binary2NitroRom.cs
+++ b/src/Ekona/Containers/Rom/Binary2NitroRom.cs
@@ -171,6 +171,11 @@ namespace SceneGate.Ekona.Containers.Rom
             programParams.BssOffset = reader.ReadUInt32();
             programParams.BssEndOffset = reader.ReadUInt32();
             programParams.CompressedLength = reader.ReadUInt32() - header.ProgramInfo.Arm9RamAddress;
+
+            ushort build = reader.ReadUInt16();
+            byte minor = reader.ReadByte();
+            byte major = reader.ReadByte();
+            programParams.SdkVersion = new Version(major, minor, build);
         }
 
         private void ReadOverlayTable(Collection<OverlayInfo> infos, uint offset, int size)

--- a/src/Ekona/Containers/Rom/Binary2NitroRom.cs
+++ b/src/Ekona/Containers/Rom/Binary2NitroRom.cs
@@ -170,7 +170,7 @@ namespace SceneGate.Ekona.Containers.Rom
             programParams.ItcmInputDataOffset = reader.ReadUInt32();
             programParams.BssOffset = reader.ReadUInt32();
             programParams.BssEndOffset = reader.ReadUInt32();
-            programParams.DecompressedLength = reader.ReadUInt32() - header.ProgramInfo.Arm9RamAddress;
+            programParams.CompressedLength = reader.ReadUInt32() - header.ProgramInfo.Arm9RamAddress;
         }
 
         private void ReadOverlayTable(Collection<OverlayInfo> infos, uint offset, int size)

--- a/src/Ekona/Containers/Rom/NitroProgramCodeParameters.cs
+++ b/src/Ekona/Containers/Rom/NitroProgramCodeParameters.cs
@@ -17,6 +17,8 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
+using System;
+
 namespace SceneGate.Ekona.Containers.Rom;
 
 /// <summary>
@@ -73,4 +75,9 @@ public class NitroProgramCodeParameters
     /// If 0, then the program is not compressed.
     /// </summary>
     public uint CompressedLength { get; set; }
+
+    /// <summary>
+    /// Gets or sets the SDK version.
+    /// </summary>
+    public Version SdkVersion { get; set; }
 }

--- a/src/Ekona/Containers/Rom/NitroProgramCodeParameters.cs
+++ b/src/Ekona/Containers/Rom/NitroProgramCodeParameters.cs
@@ -1,0 +1,76 @@
+// Copyright(c) 2022 SceneGate
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace SceneGate.Ekona.Containers.Rom;
+
+/// <summary>
+/// Nitro and twilight parameters related to the code program (arm9).
+/// </summary>
+public class NitroProgramCodeParameters
+{
+    /// <summary>
+    /// Gets or sets the offsets to the ARM9 parameters table offset in DS programs.
+    /// DSi programs have this value in the header.
+    /// </summary>
+    public uint ProgramParameterOffset { get; set; }
+
+    /// <summary>
+    /// Gets or sets the offset to an optional area in the program with additional hashes.
+    /// </summary>
+    public uint ExtraHashesOffset { get; set; }
+
+    /// <summary>
+    /// Gets or sets the ITCM first block info offset.
+    /// </summary>
+    /// <remarks>
+    /// A block info consists in two uint values: output RAM address and size.
+    /// After moving the ITCM to the output, is clean so we can reuse the place for BSS.
+    /// </remarks>
+    public uint ItcmBlockInfoOffset { get; set; }
+
+    /// <summary>
+    /// Gets or sets the end offset for the ITCM block info section.
+    /// </summary>
+    public uint ItcmBlockInfoEndOffset { get; set; }
+
+    /// <summary>
+    /// Gets or sets the ITCM input data offset.
+    /// </summary>
+    public uint ItcmInputDataOffset { get; set; }
+
+    /// <summary>
+    /// Gets or sets the BSS offset (non-initialized global/static variables area).
+    /// </summary>
+    /// <remarks>
+    /// Usually this value matches with <see cref="ItcmInputDataOffset"/>
+    /// because after moving the ITCM code, we can reuse that area.
+    /// </remarks>
+    public uint BssOffset { get; set; }
+
+    /// <summary>
+    /// Gets or sets the end offset for BSS.
+    /// </summary>
+    public uint BssEndOffset { get; set; }
+
+    /// <summary>
+    /// Gets or sets the program (arm9) decompressed length.
+    /// If 0, then the program is not compressed.
+    /// </summary>
+    public uint DecompressedLength { get; set; }
+}

--- a/src/Ekona/Containers/Rom/NitroProgramCodeParameters.cs
+++ b/src/Ekona/Containers/Rom/NitroProgramCodeParameters.cs
@@ -69,8 +69,8 @@ public class NitroProgramCodeParameters
     public uint BssEndOffset { get; set; }
 
     /// <summary>
-    /// Gets or sets the program (arm9) decompressed length.
+    /// Gets or sets the program (arm9) compressed length.
     /// If 0, then the program is not compressed.
     /// </summary>
-    public uint DecompressedLength { get; set; }
+    public uint CompressedLength { get; set; }
 }

--- a/src/Ekona/Containers/Rom/NitroRom.cs
+++ b/src/Ekona/Containers/Rom/NitroRom.cs
@@ -1,4 +1,4 @@
-﻿// Copyright(c) 2021 SceneGate
+// Copyright(c) 2021 SceneGate
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -63,6 +63,12 @@ namespace SceneGate.Ekona.Containers.Rom
             Node data = NodeFactory.CreateContainer("data");
             Root.Add(data);
         }
+
+        /// <summary>
+        /// Gets the Nitro constant in little endian: 2-10-6 (NiToRo in Japanese numbers) + 0xCODE.
+        /// It's a marker for the program code to find constants.
+        /// </summary>
+        public static uint NitroCode => 0xDEC00621;
 
         /// <summary>
         /// Gets the container with the system files of the program.

--- a/src/Ekona/Containers/Rom/NitroRom2Binary.cs
+++ b/src/Ekona/Containers/Rom/NitroRom2Binary.cs
@@ -278,6 +278,10 @@ public class NitroRom2Binary :
             writer.Write(0);
         }
 
+        writer.Write((ushort)programParams.SdkVersion.Build);
+        writer.Write((byte)programParams.SdkVersion.Minor);
+        writer.Write((byte)programParams.SdkVersion.Major);
+
         writer.Stream.PopPosition();
     }
 

--- a/src/Ekona/Containers/Rom/NitroRom2Binary.cs
+++ b/src/Ekona/Containers/Rom/NitroRom2Binary.cs
@@ -43,6 +43,7 @@ public class NitroRom2Binary :
     private readonly SortedList<int, NodeInfo> nodesByOffset = new SortedList<int, NodeInfo>();
     private Stream? initializedOutputStream;
     private DsiKeyStore? keyStore;
+    private uint? decompressedProgramLength;
     private DataWriter writer = null!;
     private Node root = null!;
     private ProgramInfo programInfo = null!;
@@ -58,6 +59,7 @@ public class NitroRom2Binary :
         ArgumentNullException.ThrowIfNull(parameters);
         initializedOutputStream = parameters.OutputStream;
         keyStore = parameters.KeyStore;
+        decompressedProgramLength = parameters.DecompressedProgramLength;
     }
 
     /// <summary>
@@ -211,6 +213,7 @@ public class NitroRom2Binary :
     private void WritePrograms()
     {
         WriteProgram(true);
+        WriteProgramCodeParameters();
         WriteOverlays(true);
 
         WriteProgram(false);
@@ -221,8 +224,6 @@ public class NitroRom2Binary :
     {
         string armPath = isArm9 ? "system/arm9" : "system/arm7";
 
-        // TODO: Update ARM9 compressed size before writing.
-        // TODO: Write ARM9 tail
         BinaryFormat binaryArm = GetChildFormatSafe<BinaryFormat>(armPath);
         uint armLength = (uint)binaryArm.Stream.Length;
         uint armOffset = armLength > 0 ? (uint)writer.Stream.Position : 0;
@@ -236,6 +237,45 @@ public class NitroRom2Binary :
             sectionInfo.Arm7Offset = armOffset;
             sectionInfo.Arm7Size = armLength;
         }
+    }
+
+    private void WriteProgramCodeParameters()
+    {
+        NitroProgramCodeParameters? programParams = programInfo.ProgramCodeParameters;
+        if (programParams is null) {
+            return;
+        }
+
+        writer.Stream.PushCurrentPosition();
+
+        // DS games don't have this header value with ARM9 param table offset.
+        // Instead, the ARM9 has a "tail" with three uint: the nitrocode, the offset and an offset to hashes.
+        uint paramsOffset = programInfo.Arm9ParametersTableOffset;
+        if (programParams.ProgramParameterOffset != 0) {
+            writer.Stream.Position = sectionInfo.Arm9Offset + sectionInfo.Arm9Size;
+            writer.Write(NitroRom.NitroCode);
+            writer.Write(programParams.ProgramParameterOffset);
+            writer.Write(programParams.ExtraHashesOffset);
+            paramsOffset = programParams.ProgramParameterOffset;
+        }
+
+        // This ARM9 code parameters are inside the ARM9.
+        // Usually, we can find the nitrocode (or their DSi variants) before and after.
+        // DSi games has more (unknown) parameters.
+        writer.Stream.Position = sectionInfo.Arm9Offset + paramsOffset;
+        writer.Write(programParams.ItcmBlockInfoOffset);
+        writer.Write(programParams.ItcmBlockInfoEndOffset);
+        writer.Write(programParams.ItcmInputDataOffset);
+        writer.Write(programParams.BssOffset);
+        writer.Write(programParams.BssEndOffset);
+
+        if (decompressedProgramLength.HasValue) {
+            programParams.DecompressedLength = decompressedProgramLength.Value;
+        }
+
+        writer.Write(programParams.DecompressedLength + programInfo.Arm9RamAddress);
+
+        writer.Stream.PopPosition();
     }
 
     private void WriteOverlays(bool isArm9)

--- a/src/Ekona/Containers/Rom/NitroRom2BinaryParams.cs
+++ b/src/Ekona/Containers/Rom/NitroRom2BinaryParams.cs
@@ -40,8 +40,7 @@ public class NitroRom2BinaryParams
     public DsiKeyStore KeyStore { get; set; }
 
     /// <summary>
-    /// Gets or sets the program (arm9) decompressed length.
-    /// If set to 0, then the program is assumed to be decompressed.
+    /// Gets or sets a value indicating whether the program (arm9) is decompressed.
     /// </summary>
-    public uint? DecompressedProgramLength { get; set; }
+    public bool DecompressedProgram { get; set; }
 }

--- a/src/Ekona/Containers/Rom/NitroRom2BinaryParams.cs
+++ b/src/Ekona/Containers/Rom/NitroRom2BinaryParams.cs
@@ -38,4 +38,10 @@ public class NitroRom2BinaryParams
     /// the hashes are not regenerated.
     /// </summary>
     public DsiKeyStore KeyStore { get; set; }
+
+    /// <summary>
+    /// Gets or sets the program (arm9) decompressed length.
+    /// If set to 0, then the program is assumed to be decompressed.
+    /// </summary>
+    public uint? DecompressedProgramLength { get; set; }
 }

--- a/src/Ekona/Containers/Rom/ProgramInfo.cs
+++ b/src/Ekona/Containers/Rom/ProgramInfo.cs
@@ -235,6 +235,11 @@ namespace SceneGate.Ekona.Containers.Rom
         public HashInfo Signature { get; set; }
 
         /// <summary>
+        /// Gets or sets the program code (arm9) parameters.
+        /// </summary>
+        public NitroProgramCodeParameters ProgramCodeParameters { get; set; } = new NitroProgramCodeParameters();
+
+        /// <summary>
         /// Gets or sets the collection of information of overlays for ARM-9.
         /// </summary>
         public Collection<OverlayInfo> Overlays9Info { get; set; } = new Collection<OverlayInfo>();


### PR DESCRIPTION
### Description

Read and write the ARM9 code parameters. This includes the "arm9 tail" in DS games, the ARM9 compressed length inside the binary and some useful pointers like BSS, ITCM and SDK version.

### Example

- The information is available from the `ProgramInfo.ProgramCodeParameters`.
- The converter `NitroRom2Binary` has a new parameter to specify if the ARM9 is provided compressed or not. If it's compressed, then it will update the compressed length. Otherwise it will set it to 0.