### PR TITLE
:sparkles: Implement DS secure area (de)encryption (KEY1) and validate/generate hashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ tools/
 
 # Test results
 test_results/
+BenchmarkDotNet.Artifacts/
 
 # Documentation output
 docs/_site

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ docs/_site_pdf
 
 # IDEs
 .vs/
-.DotSettings.user
+*.DotSettings.user

--- a/.vscode/header-cs.code-snippets
+++ b/.vscode/header-cs.code-snippets
@@ -1,0 +1,32 @@
+{
+	"Header C#": {
+		"scope": "csharp",
+		"prefix": "header",
+		"description": "Insert the C# file header",
+		"body": [
+			"// Copyright (c) 2022 SceneGate",
+			"",
+			"// Permission is hereby granted, free of charge, to any person obtaining a copy",
+			"// of this software and associated documentation files (the \"Software\"), to deal",
+			"// in the Software without restriction, including without limitation the rights",
+			"// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell",
+			"// copies of the Software, and to permit persons to whom the Software is",
+			"// furnished to do so, subject to the following conditions:",
+			"",
+			"// The above copyright notice and this permission notice shall be included in all",
+			"// copies or substantial portions of the Software.",
+			"",
+			"// THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR",
+			"// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,",
+			"// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE",
+			"// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER",
+			"// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,",
+			"// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE",
+			"// SOFTWARE.",
+			"namespace SceneGate.Ekona.$1;",
+			"",
+			"$0",
+			""
+		]
+	}
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,6 +14,7 @@
     },
     "prettier.proseWrap": "always",
     "cSpell.words": [
+        "cref",
         "Ekona"
     ],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,6 +15,7 @@
     "prettier.proseWrap": "always",
     "cSpell.words": [
         "cref",
-        "Ekona"
+        "Ekona",
+        "HMAC"
     ],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,4 +13,7 @@
         "editor.formatOnType": true
     },
     "prettier.proseWrap": "always",
+    "cSpell.words": [
+        "Ekona"
+    ],
 }

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -165,6 +165,7 @@ dotnet_diagnostic.IDE1006.severity = warning
 dotnet_diagnostic.CA1303.severity = none # We don't translate exception and log messages from English
 
 ### StyleCop
+dotnet_diagnostic.SA1009.severity = none # False positive due to nullables
 dotnet_diagnostic.SA1011.severity = none # False positive due to nullables
 dotnet_diagnostic.SA1101.severity = none # Do not force to prefix local calls with 'this'
 dotnet_diagnostic.SA1500.severity = none # Allow inline braces

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -12,6 +12,7 @@
         <PackageVersion Include="NUnit3TestAdapter" Version="4.2.1" />
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.1.0"/>
         <PackageVersion Include="coverlet.collector" Version="3.1.2" />
+        <PackageVersion Include="BenchmarkDotNet" Version="0.13.1" />
 
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
 

--- a/src/Ekona.PerformanceTests/Ekona.PerformanceTests.csproj
+++ b/src/Ekona.PerformanceTests/Ekona.PerformanceTests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AssemblyName>Ekona.PerformanceTests</AssemblyName>
+    <RootNamespace>SceneGate.Ekona.PerformanceTests</RootNamespace>
+    <Description>Tests for Ekona.</Description>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Ekona\Ekona.csproj" />
+    <PackageReference Include="BenchmarkDotNet" />
+  </ItemGroup>
+
+</Project>

--- a/src/Ekona.PerformanceTests/NitroBlowfishTest.cs
+++ b/src/Ekona.PerformanceTests/NitroBlowfishTest.cs
@@ -1,0 +1,82 @@
+// Copyright (c) 2022 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using BenchmarkDotNet.Attributes;
+using SceneGate.Ekona.Security;
+using Yarhl.IO;
+
+namespace SceneGate.Ekona.PerformanceTests;
+
+[MemoryDiagnoser]
+public class NitroBlowfishTest
+{
+    private readonly NitroBlowfish blowfish = new NitroBlowfish();
+    private readonly byte[] buffer = new byte[16 * 1024];
+    private byte[] key = null!;
+
+    public int Level => 3;
+
+    public int Modulo => 8;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var random = new Random();
+        key = new byte[NitroBlowfish.KeyLength];
+        random.NextBytes(key);
+    }
+
+    [Benchmark]
+    [Arguments(8)]
+    [Arguments(2 * 1024)]
+    public void EncryptArray(int dataLength)
+    {
+        var data = buffer[..dataLength];
+
+        blowfish.Initialize("YYYY", Level, Modulo, key);
+        blowfish.Encryption(true, data);
+    }
+
+    [Benchmark]
+    [Arguments(8)]
+    [Arguments(2 * 1024)]
+    public void EncryptStream(int dataLength)
+    {
+        using var stream = DataStreamFactory.FromArray(buffer, 0, dataLength);
+
+        blowfish.Initialize("YYYY", Level, Modulo, key);
+        blowfish.Encryption(true, stream);
+    }
+
+    [Benchmark]
+    public void Encrypt64Bits()
+    {
+        uint data0 = 0x89ABCDEF;
+        uint data1 = 0x01234567;
+
+        blowfish.Initialize("YYYY", Level, Modulo, key);
+        blowfish.Encrypt(ref data0, ref data1);
+    }
+
+    [Benchmark]
+    public void Initialization()
+    {
+        blowfish.Initialize("YYYY", Level, Modulo, key);
+    }
+}

--- a/src/Ekona.PerformanceTests/NitroBlowfishTest.cs
+++ b/src/Ekona.PerformanceTests/NitroBlowfishTest.cs
@@ -50,7 +50,7 @@ public class NitroBlowfishTest
         var data = buffer[..dataLength];
 
         blowfish.Initialize("YYYY", Level, Modulo, key);
-        blowfish.Encryption(true, data);
+        blowfish.Encrypt(data);
     }
 
     [Benchmark]
@@ -61,7 +61,7 @@ public class NitroBlowfishTest
         using var stream = DataStreamFactory.FromArray(buffer, 0, dataLength);
 
         blowfish.Initialize("YYYY", Level, Modulo, key);
-        blowfish.Encryption(true, stream);
+        blowfish.Encrypt(stream);
     }
 
     [Benchmark]

--- a/src/Ekona.PerformanceTests/Program.cs
+++ b/src/Ekona.PerformanceTests/Program.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) 2022 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace SceneGate.Ekona.PerformanceTests;
+
+public static class Program
+{
+    public static void Main()
+    {
+        BenchmarkDotNet.Running.BenchmarkRunner.Run<NitroBlowfishTest>();
+    }
+}

--- a/src/Ekona.Tests/Containers/Rom/Binary2NitroRomTests.cs
+++ b/src/Ekona.Tests/Containers/Rom/Binary2NitroRomTests.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using FluentAssertions;
+using Microsoft.VisualStudio.TestPlatform.TestHost;
 using NUnit.Framework;
 using SceneGate.Ekona.Containers.Rom;
 using SceneGate.Ekona.Security;
@@ -103,6 +104,8 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
             ProgramInfo programInfo = rom.Information;
             bool isDsi = programInfo.UnitCode != DeviceUnitKind.DS;
 
+            programInfo.ChecksumSecureArea.Status.Should().Be(HashStatus.Valid);
+
             if (isDsi || programInfo.ProgramFeatures.HasFlag(DsiRomFeatures.BannerSigned)) {
                 programInfo.BannerMac.Status.Should().Be(HashStatus.Valid);
             }
@@ -175,13 +178,13 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
             using Node node = NodeFactory.FromFile(romPath, FileOpenMode.Read);
 
             node.Invoking(n => n.TransformWith<Binary2NitroRom>()).Should().NotThrow();
-            ProgramInfo originalInfo = node.GetFormatAs<NitroRom>().Information;
+            ProgramInfo originalInfo = node.GetFormatAs<NitroRom>()!.Information;
 
             var nitroParameters = new NitroRom2BinaryParams { KeyStore = keys };
             node.Invoking(n => n.TransformWith<NitroRom2Binary, NitroRom2BinaryParams>(nitroParameters)).Should().NotThrow();
 
             node.Invoking(n => n.TransformWith<Binary2NitroRom>()).Should().NotThrow();
-            ProgramInfo newInfo = node.GetFormatAs<NitroRom>().Information;
+            ProgramInfo newInfo = node.GetFormatAs<NitroRom>()!.Information;
 
             newInfo.OverlaysMac.Hash.Should().BeEquivalentTo(originalInfo.OverlaysMac.Hash);
             newInfo.BannerMac.Hash.Should().BeEquivalentTo(originalInfo.BannerMac.Hash);

--- a/src/Ekona.Tests/Containers/Rom/Binary2NitroRomTests.cs
+++ b/src/Ekona.Tests/Containers/Rom/Binary2NitroRomTests.cs
@@ -182,13 +182,13 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
 
                 // Not regenerated but should keep it
                 newInfo.Signature.Hash.Should().BeEquivalentTo(originalInfo.Signature.Hash);
-                newInfo.NitroProgramMac.Status.Should().Be(HashStatus.NotValidated); // not generated
+                newInfo.Signature.Status.Should().Be(HashStatus.NotValidated); // not generated
             }
 
             if (isDsi) {
                 // Not regenerated but should keep it
                 newInfo.Signature.Hash.Should().BeEquivalentTo(originalInfo.Signature.Hash);
-                newInfo.NitroProgramMac.Status.Should().Be(HashStatus.NotValidated); // not generated
+                newInfo.Signature.Status.Should().Be(HashStatus.NotValidated); // not generated
             }
         }
 

--- a/src/Ekona.Tests/Containers/Rom/Binary2NitroRomTests.cs
+++ b/src/Ekona.Tests/Containers/Rom/Binary2NitroRomTests.cs
@@ -111,15 +111,14 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
             }
 
             if (programInfo.ProgramFeatures.HasFlag(DsiRomFeatures.ProgramSigned)) {
-                // TODO: Verify header (0x160 bytes) + armX (secure area encrypted) HMAC
-                // programInfo.ProgramMac.Status.Should().Be(HashStatus.Valid)
+                programInfo.ProgramMac.Status.Should().Be(HashStatus.Valid);
                 programInfo.OverlaysMac.Status.Should().Be(HashStatus.Valid);
                 programInfo.Signature.Status.Should().Be(HashStatus.Valid);
             }
 
             if (isDsi) {
-                programInfo.OverlaysMac.IsNull.Should().BeTrue();
                 programInfo.ProgramMac.IsNull.Should().BeTrue();
+                programInfo.OverlaysMac.IsNull.Should().BeTrue();
                 programInfo.Signature.Status.Should().Be(HashStatus.Valid);
             }
         }

--- a/src/Ekona.Tests/Containers/Rom/Binary2RomHeaderTests.cs
+++ b/src/Ekona.Tests/Containers/Rom/Binary2RomHeaderTests.cs
@@ -85,20 +85,20 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
             programInfo.ChecksumHeader.Status.Should().Be(HashStatus.Valid);
 
             bool isDsi = programInfo.UnitCode != DeviceUnitKind.DS;
-            if (isDsi || programInfo.ProgramFeatures.HasFlag(DsiRomFeatures.BannerSigned)) {
+            if (isDsi || programInfo.ProgramFeatures.HasFlag(DsiRomFeatures.NitroBannerSigned)) {
                 programInfo.BannerMac.Should().NotBeNull();
                 programInfo.BannerMac.Status.Should().Be(HashStatus.NotValidated);
             }
 
-            if (programInfo.ProgramFeatures.HasFlag(DsiRomFeatures.ProgramSigned)) {
-                programInfo.OverlaysMac.Should().NotBeNull();
-                programInfo.OverlaysMac.Status.Should().Be(HashStatus.NotValidated);
+            if (programInfo.ProgramFeatures.HasFlag(DsiRomFeatures.NitroProgramSigned)) {
+                programInfo.NitroOverlaysMac.Should().NotBeNull();
+                programInfo.NitroOverlaysMac.Status.Should().Be(HashStatus.NotValidated);
 
-                programInfo.ProgramMac.Should().NotBeNull();
-                programInfo.ProgramMac.Status.Should().Be(HashStatus.NotValidated);
+                programInfo.NitroProgramMac.Should().NotBeNull();
+                programInfo.NitroProgramMac.Status.Should().Be(HashStatus.NotValidated);
             }
 
-            if (isDsi || programInfo.ProgramFeatures.HasFlag(DsiRomFeatures.ProgramSigned)) {
+            if (isDsi || programInfo.ProgramFeatures.HasFlag(DsiRomFeatures.NitroProgramSigned)) {
                 programInfo.Signature.Should().NotBeNull();
                 programInfo.Signature.Status.Should().Be(HashStatus.NotValidated);
             }
@@ -134,7 +134,9 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
             using var generatedStream = (BinaryFormat)ConvertFormat.With<RomHeader2Binary>(originalHeader);
             var generatedHeader = (RomHeader)ConvertFormat.With<Binary2RomHeader>(generatedStream);
 
-            generatedHeader.Should().BeEquivalentTo(originalHeader);
+            generatedHeader.Should().BeEquivalentTo(
+                originalHeader,
+                opts => opts.Excluding((FluentAssertions.Equivalency.IMemberInfo info) => info.Type == typeof(HashInfo)));
         }
     }
 }

--- a/src/Ekona.Tests/Security/NitroBlowfishTests.cs
+++ b/src/Ekona.Tests/Security/NitroBlowfishTests.cs
@@ -1,0 +1,106 @@
+// Copyright (c) 2022 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using FluentAssertions;
+using NUnit.Framework;
+using SceneGate.Ekona.Security;
+using Yarhl.IO;
+
+namespace SceneGate.Ekona.Tests.Security;
+
+[TestFixture]
+public class NitroBlowfishTest
+{
+    [Test]
+    [TestCase(new uint[] { 0x01234567, 0x89ABCDEF }, "AAAA", 2, 8, new uint[] { 0xECD83DAE, 0xAB3EF361 })]
+    public void Decrypt(uint[] data, string idCode, int level, int modulo, uint[] expected)
+    {
+        DsiKeyStore keys = TestDataBase.GetDsiKeyStore();
+        var blowfish = new NitroBlowfish();
+        blowfish.Initialize(idCode, level, modulo, keys.BlowfishDsKey);
+
+        blowfish.Decrypt(ref data[0], ref data[1]);
+        data.Should().BeEquivalentTo(expected);
+    }
+
+    [Test]
+    [TestCase(new uint[] { 0xECD83DAE, 0xAB3EF361 }, "AAAA", 2, 8, new uint[] { 0x01234567, 0x89ABCDEF })]
+    public void Encrypt(uint[] data, string idCode, int level, int modulo, uint[] expected)
+    {
+        DsiKeyStore keys = TestDataBase.GetDsiKeyStore();
+        var blowfish = new NitroBlowfish();
+        blowfish.Initialize(idCode, level, modulo, keys.BlowfishDsKey);
+
+        blowfish.Encrypt(ref data[0], ref data[1]);
+        data.Should().BeEquivalentTo(expected);
+    }
+
+    [Test]
+    public void StreamEncDecryption()
+    {
+        using var stream = new DataStream();
+        var inputWriter = new DataWriter(stream);
+        inputWriter.Write(0xECD83DAE);
+        inputWriter.Write(0xAB3EF361);
+
+        DsiKeyStore keys = TestDataBase.GetDsiKeyStore();
+        var blowfish = new NitroBlowfish();
+        blowfish.Initialize("AAAA", 2, 8, keys.BlowfishDsKey);
+
+        blowfish.Encryption(true, stream);
+
+        stream.Position = 0;
+        var outputReader = new DataReader(stream);
+        outputReader.ReadUInt32().Should().Be(0x01234567);
+        outputReader.ReadUInt32().Should().Be(0x89ABCDEF);
+
+        blowfish.Encryption(false, stream);
+
+        stream.Position = 0;
+        outputReader.ReadUInt32().Should().Be(0xECD83DAE);
+        outputReader.ReadUInt32().Should().Be(0xAB3EF361);
+    }
+
+    [Test]
+    public void ArrayEncDecryption()
+    {
+        using var inputStream = new DataStream();
+        var inputWriter = new DataWriter(inputStream);
+        inputWriter.Write(0xECD83DAE);
+        inputWriter.Write(0xAB3EF361);
+        byte[] input = new byte[8];
+        inputStream.Position = 0;
+        inputStream.Read(input);
+
+        DsiKeyStore keys = TestDataBase.GetDsiKeyStore();
+        var blowfish = new NitroBlowfish();
+        blowfish.Initialize("AAAA", 2, 8, keys.BlowfishDsKey);
+
+        byte[] output = blowfish.Encryption(true, input);
+
+        using var outputStream = DataStreamFactory.FromArray(output);
+        var outputReader = new DataReader(outputStream);
+        outputReader.ReadUInt32().Should().Be(0x01234567);
+        outputReader.ReadUInt32().Should().Be(0x89ABCDEF);
+
+        byte[] finalEncryption = blowfish.Encryption(false, output);
+
+        finalEncryption.Should().BeEquivalentTo(input);
+    }
+}

--- a/src/Ekona.Tests/Security/NitroKey1EncryptionTests.cs
+++ b/src/Ekona.Tests/Security/NitroKey1EncryptionTests.cs
@@ -1,0 +1,53 @@
+// Copyright(c) 2022 SceneGate
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using System.Text;
+using FluentAssertions;
+using NUnit.Framework;
+using SceneGate.Ekona.Security;
+
+namespace SceneGate.Ekona.Tests.Security;
+
+[TestFixture]
+public class NitroKey1EncryptionTests
+{
+    [Test]
+    [TestCase(new byte[] { 0x1D, 0x9E, 0xBA, 0xC7, 0xBB, 0x0E, 0x9E, 0x6A }, "B2KJ")]
+    public void DecryptSecureAreaId(byte[] encrypted, string idCode)
+    {
+        DsiKeyStore keys = TestDataBase.GetDsiKeyStore();
+
+        byte[] decrypted = NitroKey1Encryption.DecryptSecureAreaId(encrypted, idCode, keys);
+
+        string actualToken = Encoding.ASCII.GetString(decrypted);
+        actualToken.Should().BeEquivalentTo("encryObj");
+    }
+
+    [Test]
+    [TestCase(new byte[] { 0x1D, 0x9E, 0xBA, 0xC7, 0xBB, 0x0E, 0x9E, 0x6A }, "B2KJ")]
+    public void EncryptSecureAreaId(byte[] encrypted, string idCode)
+    {
+        DsiKeyStore keys = TestDataBase.GetDsiKeyStore();
+
+        byte[] token = Encoding.ASCII.GetBytes("encryObj");
+        byte[] actualEncrypted = NitroKey1Encryption.EncryptSecureAreaId(token, idCode, keys);
+
+        actualEncrypted.Should().BeEquivalentTo(encrypted);
+    }
+}

--- a/src/Ekona.Tests/Security/NitroKey1EncryptionTests.cs
+++ b/src/Ekona.Tests/Security/NitroKey1EncryptionTests.cs
@@ -17,16 +17,42 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-using System.Text;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using FluentAssertions;
 using NUnit.Framework;
+using SceneGate.Ekona.Containers.Rom;
 using SceneGate.Ekona.Security;
+using Yarhl.FileSystem;
+using Yarhl.IO;
 
 namespace SceneGate.Ekona.Tests.Security;
 
 [TestFixture]
 public class NitroKey1EncryptionTests
 {
+    public static IEnumerable<TestCaseData> GetRoms()
+    {
+        string basePath = Path.Combine(TestDataBase.RootFromOutputPath, "Containers");
+        string listPath = Path.Combine(basePath, "rom.txt");
+        return TestDataBase.ReadTestListFile(listPath)
+            .Select(line => line.Split(','))
+            .Select(data => new TestCaseData(Path.Combine(basePath, data[1]))
+                .SetName($"{{m}}({data[1]})"));
+    }
+
+    [Test]
+    public void GenerateDisabledSecureAreaMatch()
+    {
+        DsiKeyStore keys = TestDataBase.GetDsiKeyStore();
+        var encryption = new NitroKey1Encryption("AAAA", keys);
+
+        byte[] token = encryption.GenerateEncryptedDisabledSecureAreaToken();
+
+        encryption.HasDisabledSecureArea(token).Should().BeTrue();
+    }
+
     [Test]
     [TestCase(new byte[] { 0x1D, 0x9E, 0xBA, 0xC7, 0xBB, 0x0E, 0x9E, 0x6A }, "B2KJ")]
     public void DecryptSecureAreaId(byte[] encrypted, string idCode)
@@ -34,10 +60,7 @@ public class NitroKey1EncryptionTests
         DsiKeyStore keys = TestDataBase.GetDsiKeyStore();
 
         var encryption = new NitroKey1Encryption(idCode, keys);
-        byte[] decrypted = encryption.DecryptSecureAreaId(encrypted);
-
-        string actualToken = Encoding.ASCII.GetString(decrypted);
-        actualToken.Should().BeEquivalentTo("encryObj");
+        encryption.HasValidSecureAreaId(encrypted).Should().BeTrue();
     }
 
     [Test]
@@ -47,9 +70,40 @@ public class NitroKey1EncryptionTests
         DsiKeyStore keys = TestDataBase.GetDsiKeyStore();
         var encryption = new NitroKey1Encryption(idCode, keys);
 
-        byte[] token = Encoding.ASCII.GetBytes("encryObj");
-        byte[] actualEncrypted = encryption.EncryptSecureAreaId(token);
-
+        byte[] actualEncrypted = encryption.GenerateEncryptedSecureAreaId();
         actualEncrypted.Should().BeEquivalentTo(encrypted);
+    }
+
+    [TestCaseSource(nameof(GetRoms))]
+    public void EncryptedDecryptArm9IsIdentical(string romPath)
+    {
+        TestDataBase.IgnoreIfFileDoesNotExist(romPath);
+        DsiKeyStore keys = TestDataBase.GetDsiKeyStore();
+
+        using Node node = NodeFactory.FromFile(romPath, FileOpenMode.Read);
+        node.TransformWith<Binary2NitroRom>();
+        var nitroRom = node.GetFormatAs<NitroRom>();
+        var originalArm9 = nitroRom.System.Children["arm9"].Stream!;
+
+        var encryption = new NitroKey1Encryption(nitroRom.Information.GameCode, keys);
+        using var encryptedArm9 = encryption.EncryptArm9(originalArm9);
+        using var decryptedArm9 = encryption.DecryptArm9(encryptedArm9);
+
+        decryptedArm9.Compare(originalArm9).Should().BeTrue();
+    }
+
+    [TestCaseSource(nameof(GetRoms))]
+    public void GameSecureAreaAreDecrypted(string romPath)
+    {
+        TestDataBase.IgnoreIfFileDoesNotExist(romPath);
+        DsiKeyStore keys = TestDataBase.GetDsiKeyStore();
+
+        using Node node = NodeFactory.FromFile(romPath, FileOpenMode.Read);
+        node.TransformWith<Binary2NitroRom>();
+        var nitroRom = node.GetFormatAs<NitroRom>();
+        var originalArm9 = nitroRom.System.Children["arm9"].Stream!;
+
+        var encryption = new NitroKey1Encryption(nitroRom.Information.GameCode, keys);
+        encryption.HasEncryptedArm9(originalArm9).Should().BeFalse();
     }
 }

--- a/src/Ekona.Tests/Security/NitroKey1EncryptionTests.cs
+++ b/src/Ekona.Tests/Security/NitroKey1EncryptionTests.cs
@@ -33,7 +33,8 @@ public class NitroKey1EncryptionTests
     {
         DsiKeyStore keys = TestDataBase.GetDsiKeyStore();
 
-        byte[] decrypted = NitroKey1Encryption.DecryptSecureAreaId(encrypted, idCode, keys);
+        var encryption = new NitroKey1Encryption(idCode, keys);
+        byte[] decrypted = encryption.DecryptSecureAreaId(encrypted);
 
         string actualToken = Encoding.ASCII.GetString(decrypted);
         actualToken.Should().BeEquivalentTo("encryObj");
@@ -44,9 +45,10 @@ public class NitroKey1EncryptionTests
     public void EncryptSecureAreaId(byte[] encrypted, string idCode)
     {
         DsiKeyStore keys = TestDataBase.GetDsiKeyStore();
+        var encryption = new NitroKey1Encryption(idCode, keys);
 
         byte[] token = Encoding.ASCII.GetBytes("encryObj");
-        byte[] actualEncrypted = NitroKey1Encryption.EncryptSecureAreaId(token, idCode, keys);
+        byte[] actualEncrypted = encryption.EncryptSecureAreaId(token);
 
         actualEncrypted.Should().BeEquivalentTo(encrypted);
     }

--- a/src/Ekona.sln
+++ b/src/Ekona.sln
@@ -15,6 +15,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Packages.props = Directory.Packages.props
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ekona.PerformanceTests", "Ekona.PerformanceTests\Ekona.PerformanceTests.csproj", "{5808F29C-C802-4728-99A5-E1F299178002}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -29,6 +31,10 @@ Global
 		{487D33E4-F410-49A5-832B-986DF19E1A91}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{487D33E4-F410-49A5-832B-986DF19E1A91}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{487D33E4-F410-49A5-832B-986DF19E1A91}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5808F29C-C802-4728-99A5-E1F299178002}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5808F29C-C802-4728-99A5-E1F299178002}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5808F29C-C802-4728-99A5-E1F299178002}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5808F29C-C802-4728-99A5-E1F299178002}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Ekona/Containers/Rom/Binary2NitroRom.cs
+++ b/src/Ekona/Containers/Rom/Binary2NitroRom.cs
@@ -35,6 +35,7 @@ namespace SceneGate.Ekona.Containers.Rom
     /// </summary>
     public class Binary2NitroRom : IConverter<IBinary, NitroRom>, IInitializer<DsiKeyStore>
     {
+        private const int SecureAreaLength = 16 * 1024;
         private static readonly FileAddressOffsetComparer FileAddressComparer = new FileAddressOffsetComparer();
 
         private DsiKeyStore keyStore;
@@ -260,28 +261,31 @@ namespace SceneGate.Ekona.Containers.Rom
 
             ProgramInfo programInfo = header.ProgramInfo;
             bool isDsi = programInfo.UnitCode != DeviceUnitKind.DS;
-            var encryption = new NitroKey1Encryption(programInfo.GameCode, keyStore);
+            var key1Encryption = new NitroKey1Encryption(programInfo.GameCode, keyStore);
             var hashGenerator = new TwilightHMacGenerator(keyStore);
             var crcGenerator = new NitroCrcGenerator();
 
+            // Get ARM9 encrypted (or encrypt it) since it's used for several CRC / hashes
             DataStream arm9 = rom.System.Children["arm9"].Stream!;
-            DataStream encryptedArm9;
-            if (!encryption.HasEncryptedArm9(arm9)) {
-                encryptedArm9 = encryption.EncryptArm9(arm9);
-            } else {
-                encryptedArm9 = new DataStream(arm9);
+            using DataStream encryptedArm9 = key1Encryption.HasEncryptedArm9(arm9)
+                ? new DataStream(arm9)
+                : key1Encryption.EncryptArm9(arm9);
+
+            // Header secure area CRC
+            byte[] secureAreaCrc = crcGenerator.GenerateCrc16(encryptedArm9, 0, SecureAreaLength);
+            programInfo.ChecksumSecureArea.Validate(secureAreaCrc);
+
+            // HMAC for phase 1 and 2 of DS games
+            bool checkPhase12 = programInfo.ProgramFeatures.HasFlag(DsiRomFeatures.ProgramSigned);
+            if (checkPhase12 && keyStore.HMacKeyWhitelist12 is { Length: > 0 }) {
+                byte[] phase1Hash = hashGenerator.GeneratePhase1Hmac(reader.Stream, encryptedArm9, header.SectionInfo);
+                programInfo.ProgramMac.Validate(phase1Hash);
+
+                byte[] phase2Hash = hashGenerator.GeneratePhase2Hmac(reader.Stream, header.SectionInfo);
+                programInfo.OverlaysMac.Validate(phase2Hash);
             }
 
-            byte[] actualCrc = crcGenerator.GenerateCrc16(encryptedArm9, 0, 16 * 1024);
-            programInfo.ChecksumSecureArea.Validate(actualCrc);
-
-            // TODO: Verify header (0x160 bytes) + armX (secure area encrypted) HMAC
-            bool checkOverlayHmac = programInfo.ProgramFeatures.HasFlag(DsiRomFeatures.ProgramSigned);
-            if (keyStore.HMacKeyWhitelist12?.Length > 0 && checkOverlayHmac) {
-                byte[] actualHash = hashGenerator.GeneratePhase2Hmac(reader.Stream, header.SectionInfo);
-                programInfo.OverlaysMac.Validate(actualHash);
-            }
-
+            // HMAC for banner of DS and DSi games
             byte[] bannerKey = isDsi ? keyStore.HMacKeyDSiGames : keyStore.HMacKeyWhitelist34;
             bool checkBannerHmac = isDsi || programInfo.ProgramFeatures.HasFlag(DsiRomFeatures.BannerSigned);
             if (bannerKey?.Length > 0 && checkBannerHmac) {
@@ -289,13 +293,12 @@ namespace SceneGate.Ekona.Containers.Rom
                 programInfo.BannerMac.Validate(actualHash);
             }
 
+            // ROM signature of DS and DSi games
             bool checkSignature = isDsi || programInfo.ProgramFeatures.HasFlag(DsiRomFeatures.ProgramSigned);
             if (keyStore.PublicModulusRetailGames?.Length > 0 && checkSignature) {
                 var signer = new TwilightSigner(keyStore.PublicModulusRetailGames);
                 programInfo.Signature.Status = signer.VerifySignature(programInfo.Signature.Hash, reader.Stream);
             }
-
-            encryptedArm9.Dispose();
         }
 
         private struct FileAddress

--- a/src/Ekona/Containers/Rom/Binary2NitroRom.cs
+++ b/src/Ekona/Containers/Rom/Binary2NitroRom.cs
@@ -260,13 +260,14 @@ namespace SceneGate.Ekona.Containers.Rom
 
             ProgramInfo programInfo = header.ProgramInfo;
             bool isDsi = programInfo.UnitCode != DeviceUnitKind.DS;
+            var encryption = new NitroKey1Encryption(programInfo.GameCode, keyStore);
             var hashGenerator = new TwilightHMacGenerator(keyStore);
             var crcGenerator = new NitroCrcGenerator();
 
             DataStream arm9 = rom.System.Children["arm9"].Stream!;
             DataStream encryptedArm9;
-            if (!NitroKey1Encryption.HasEncryptedArm9(arm9, programInfo, keyStore)) {
-                encryptedArm9 = NitroKey1Encryption.EncryptArm9(arm9, programInfo.GameCode, keyStore);
+            if (!encryption.HasEncryptedArm9(arm9)) {
+                encryptedArm9 = encryption.EncryptArm9(arm9);
             } else {
                 encryptedArm9 = new DataStream(arm9);
             }

--- a/src/Ekona/Containers/Rom/DsiRomFeatures.cs
+++ b/src/Ekona/Containers/Rom/DsiRomFeatures.cs
@@ -53,14 +53,14 @@ public enum DsiRomFeatures
     ShowWirelessIcon = 1 << 4,
 
     /// <summary>
-    /// ROM contains an HMAC of the icon.
+    /// DS ROM contains an HMAC of the icon.
     /// </summary>
-    BannerSigned = 1 << 5,
+    NitroBannerSigned = 1 << 5,
 
     /// <summary>
-    /// Program contains an HMAC and RSA signature of the header and programs.
+    /// DS Program contains an HMAC and RSA signature of the header and programs.
     /// </summary>
-    ProgramSigned = 1 << 6,
+    NitroProgramSigned = 1 << 6,
 
     /// <summary>
     /// ROM is a developer application.

--- a/src/Ekona/Containers/Rom/ProgramInfo.cs
+++ b/src/Ekona/Containers/Rom/ProgramInfo.cs
@@ -116,9 +116,6 @@ namespace SceneGate.Ekona.Containers.Rom
         /// <summary>
         /// Gets or sets the checksum of the ARM-9 secure area.
         /// </summary>
-        /// <remarks>
-        /// This checksum will always fail as the secure area is not easy dumpeable.
-        /// </remarks>
         public HashInfo ChecksumSecureArea { get; set; }
 
         /// <summary>
@@ -137,9 +134,9 @@ namespace SceneGate.Ekona.Containers.Rom
         public uint Arm7Autoload { get; set; }
 
         /// <summary>
-        /// Gets or sets the special value that disables the secure area encryption.
+        /// Gets or sets a value indicating whether the ARM9 secure are encryption is disabled.
         /// </summary>
-        public ulong SecureDisable { get; set; }
+        public bool DisableSecureArea { get; set; }
 
         /// <summary>
         /// Gets or sets the checksum of the copyright logo.

--- a/src/Ekona/Containers/Rom/ProgramInfo.cs
+++ b/src/Ekona/Containers/Rom/ProgramInfo.cs
@@ -211,17 +211,17 @@ namespace SceneGate.Ekona.Containers.Rom
         /// Gets or sets the SHA-1 HMAC of the header, encrypted ARM9 and ARM7 programs.
         /// </summary>
         /// <remarks>
-        /// Only for DSi games and DS games released after the DSi. Otherwise null.
+        /// Only for DS games released after the DSi. Otherwise null.
         /// </remarks>
-        public HashInfo ProgramMac { get; set; }
+        public HashInfo NitroProgramMac { get; set; }
 
         /// <summary>
         /// Gets or sets the SHA-1 HMAC of the overlays of the ARM9.
         /// </summary>
         /// <remarks>
-        /// Only for DSi games and DS games released after the DSi. Otherwise null.
+        /// Only for DS games released after the DSi. Otherwise null.
         /// </remarks>
-        public HashInfo OverlaysMac { get; set; }
+        public HashInfo NitroOverlaysMac { get; set; }
 
         /// <summary>
         /// Gets or sets the RSA SHA-1 signature of the ROM header.

--- a/src/Ekona/Security/DsiKeyStore.cs
+++ b/src/Ekona/Security/DsiKeyStore.cs
@@ -25,11 +25,21 @@ namespace SceneGate.Ekona.Security;
 public class DsiKeyStore
 {
     /// <summary>
+    /// Gets or sets the key for the Blowfish (KEY1) encryption of DS mode.
+    /// </summary>
+    /// <remarks>
+    /// The key can be found in the DS ARM7 BIOS from 0x30 to 0x1077.
+    /// It starts with `99 D5 20 5F`.
+    /// </remarks>
+    public byte[] BlowfishDsKey { get; set; }
+
+    /// <summary>
     /// Gets or sets the HMAC key for the DS whitelist phases 1 and 2.
     /// </summary>
     /// <remarks>
     /// The key can be found in the DSi launcher application ARM9.
     /// For instance, at position 0270EC90h of the RAM.
+    /// It starts with `61 BD DD 72`.
     /// </remarks>
     public byte[] HMacKeyWhitelist12 { get; set; }
 
@@ -39,6 +49,7 @@ public class DsiKeyStore
     /// <remarks>
     /// The key can be found in the DSi launcher application ARM9.
     /// For instance, at position 0270ECD0h of the RAM.
+    /// It starts with `85 29 48 F3`.
     /// </remarks>
     public byte[] HMacKeyWhitelist34 { get; set; }
 
@@ -47,6 +58,7 @@ public class DsiKeyStore
     /// </summary>
     /// <remarks>
     /// The key can be found inside the ARM9 of most DSi games and in the launcher.
+    /// It starts with `21 06 C0 DE`.
     /// </remarks>
     public byte[] HMacKeyDSiGames { get; set; }
 
@@ -55,6 +67,7 @@ public class DsiKeyStore
     /// </summary>
     /// <remarks>
     /// The data can be found in the ARM9 BIOS of the DSi at position 0x8974.
+    /// It starts with `95 6F 79 0D`.
     /// </remarks>
     public byte[] PublicModulusRetailGames { get; set; }
 }

--- a/src/Ekona/Security/HashInfo.cs
+++ b/src/Ekona/Security/HashInfo.cs
@@ -84,6 +84,6 @@ public class HashInfo
     public void ChangeHash(byte[] newHash)
     {
         Hash = newHash;
-        Status = HashStatus.Valid;
+        Status = HashStatus.Generated;
     }
 }

--- a/src/Ekona/Security/HashStatus.cs
+++ b/src/Ekona/Security/HashStatus.cs
@@ -38,4 +38,9 @@ public enum HashStatus
     /// The hash has been validated and is not valid.
     /// </summary>
     Invalid,
+
+    /// <summary>
+    /// The hash has been regenerated from the data, so it's valid.
+    /// </summary>
+    Generated,
 }

--- a/src/Ekona/Security/NitroBlowfish.cs
+++ b/src/Ekona/Security/NitroBlowfish.cs
@@ -1,0 +1,195 @@
+// Copyright (c) 2022 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#nullable enable
+using System;
+using System.Text;
+using Yarhl.IO;
+
+namespace SceneGate.Ekona.Security;
+
+/// <summary>
+/// Encrypt and decrypt with the blowfish based algorithm used in DS.
+/// </summary>
+public class NitroBlowfish
+{
+    private readonly byte[] keyBuffer = new byte[KeyLength];
+
+    /// <summary>
+    /// Gets the required length of the key.
+    /// </summary>
+    public static int KeyLength => 0x1048;
+
+    /// <summary>
+    /// Initialize the algorithm.
+    /// </summary>
+    /// <param name="idCodeText">The ID code to initialize the key.</param>
+    /// <param name="level">The level of key initialization.</param>
+    /// <param name="modulo">The modulo to initialize the key.</param>
+    /// <param name="key">The key data of 0x1048 bytes.</param>
+    public void Initialize(string idCodeText, int level, int modulo, byte[] key)
+    {
+        ArgumentNullException.ThrowIfNull(idCodeText);
+        ArgumentNullException.ThrowIfNull(key);
+        if (idCodeText.Length != 4)
+            throw new ArgumentException("Length must be 4", nameof(idCodeText));
+        if (key.Length != KeyLength)
+            throw new ArgumentException($"Length must be {KeyLength}", nameof(key));
+
+        Array.Copy(key, keyBuffer, key.Length);
+        uint[] keyCode = new uint[3];
+
+        byte[] idCodeBin = Encoding.ASCII.GetBytes(idCodeText);
+        uint idCode = BitConverter.ToUInt32(idCodeBin);
+        keyCode[0] = idCode;
+        keyCode[1] = idCode >> 1;
+        keyCode[2] = idCode << 1;
+
+        if (level >= 1) {
+            ApplyKeyCode(modulo, keyCode);
+        }
+
+        if (level >= 2) {
+            ApplyKeyCode(modulo, keyCode);
+        }
+
+        keyCode[1] <<= 1;
+        keyCode[2] >>= 1;
+
+        if (level >= 3) {
+            ApplyKeyCode(modulo, keyCode);
+        }
+    }
+
+    /// <summary>
+    /// Encrypt or decrypt 64-bits.
+    /// </summary>
+    /// <param name="encrypt">If set to `true`, the data is encrypted, otherwise it's decrypted.</param>
+    /// <param name="data0">The first pair of 32-bits to (d)encrypt.</param>
+    /// <param name="data1">The second pair of 32-bits to (d)encrypt.</param>
+    public void Encryption(bool encrypt, ref uint data0, ref uint data1)
+    {
+        uint y = data0;
+        uint x = data1;
+
+        int iStart = encrypt ? 0 : 0x11;
+        int iEnd = encrypt ? 0x0F : 0x02;
+        int iDiff = encrypt ? 1 : -1;
+        for (int i = iStart; i != iEnd + iDiff; i += iDiff) {
+            uint z = GetKeyBuffer(i * 4) ^ x;
+            x = GetKeyBuffer(0x048 + (((z >> 24) & 0xFF) * 4));
+            x += GetKeyBuffer(0x448 + (((z >> 16) & 0xFF) * 4));
+            x ^= GetKeyBuffer(0x848 + (((z >> 8) & 0xFF) * 4));
+            x += GetKeyBuffer(0xC48 + (((z >> 0) & 0xFF) * 4));
+            x ^= y;
+            y = z;
+        }
+
+        uint xorX = GetKeyBuffer(encrypt ? 0x40 : 0x04);
+        data0 = x ^ xorX;
+
+        uint xorY = GetKeyBuffer(encrypt ? 0x44 : 0x00);
+        data1 = y ^ xorY;
+    }
+
+    public void Encryption(bool encrypt, DataStream stream)
+    {
+        var reader = new DataReader(stream);
+        var writer = new DataWriter(stream);
+
+        stream.Position = 0;
+        while (stream.Position + 8 <= stream.Length) {
+            uint data0 = reader.ReadUInt32();
+            uint data1 = reader.ReadUInt32();
+
+            Encryption(encrypt, ref data0, ref data1);
+
+            stream.Position -= 8;
+            writer.Write(data0);
+            writer.Write(data1);
+        }
+    }
+
+    public byte[] Encryption(bool encrypt, byte[] data)
+    {
+        byte[] output = new byte[data.Length];
+
+        using DataStream inputStream = DataStreamFactory.FromArray(data);
+        var reader = new DataReader(inputStream);
+
+        for (int i = 0; i + 8 <= data.Length; i += 8) {
+            uint data0 = reader.ReadUInt32();
+            uint data1 = reader.ReadUInt32();
+
+            Encryption(encrypt, ref data0, ref data1);
+
+            Array.Copy(BitConverter.GetBytes(data0), 0, output, i, 4);
+            Array.Copy(BitConverter.GetBytes(data1), 0, output, i + 4, 4);
+        }
+
+        return output;
+    }
+
+    private void ApplyKeyCode(int modulo, uint[] keyCode)
+    {
+        uint GetMixValue(uint[] array, int bytePos)
+        {
+            uint val = 0;
+            for (int i = 3; i >= 0; i--) {
+                val <<= 8;
+
+                int pos = bytePos + i;
+                int bPos = pos / 4;
+                int bitPos = (pos % 4) * 8;
+                val |= (byte)(array[bPos] >> (24 - bitPos));
+            }
+
+            return val;
+        }
+
+        Encryption(true, ref keyCode[1], ref keyCode[2]);
+        Encryption(true, ref keyCode[0], ref keyCode[1]);
+
+        for (int i = 0; i <= 0x44; i += 4) {
+            uint xorValue = GetMixValue(keyCode, i % modulo);
+            uint value = GetUInt32(keyBuffer, i);
+            SetUInt32(keyBuffer, i, value ^ xorValue);
+        }
+
+        uint scratch0 = 0;
+        uint scratch1 = 0;
+        for (int i = 0; i <= 0x1040; i += 8) {
+            Encryption(true, ref scratch0, ref scratch1);
+            SetUInt32(keyBuffer, i, scratch1);
+            SetUInt32(keyBuffer, i + 4, scratch0);
+        }
+    }
+
+    private uint GetKeyBuffer(int pos) => GetUInt32(keyBuffer, pos);
+
+    private uint GetKeyBuffer(uint pos) => GetKeyBuffer((int)pos);
+
+    private void SetUInt32(byte[] buffer, int pos, uint value)
+    {
+        byte[] data = BitConverter.GetBytes(value);
+        Array.Copy(data, 0, buffer, pos, data.Length);
+    }
+
+    private uint GetUInt32(byte[] buffer, int pos) => BitConverter.ToUInt32(buffer, pos);
+}

--- a/src/Ekona/Security/NitroKey1Encryption.cs
+++ b/src/Ekona/Security/NitroKey1Encryption.cs
@@ -31,32 +31,86 @@ namespace SceneGate.Ekona.Security;
 /// </summary>
 public class NitroKey1Encryption
 {
+    private const string DisableSecureAreaToken = "NmMdOnly";
+    private const string SecureAreaId = "encryObj";
     private const int EncryptedSecureAreaLength = 2 * 1024;
     private static readonly byte[] DestroyedSecureId = { 0xFF, 0xDE, 0xFF, 0xE7, 0xFF, 0xDE, 0xFF, 0xE7 };
-    private readonly byte[] keyBuffer = new byte[0x1048];
 
-    public static byte[] DecryptSecureAreaId(byte[] data, string gameCode, DsiKeyStore keys)
+    private readonly string gameCode;
+    private readonly DsiKeyStore keyStore;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NitroKey1Encryption" /> class.
+    /// </summary>
+    /// <param name="gameCode"></param>
+    /// <param name="keyStore"></param>
+    /// <exception cref="ArgumentNullException"></exception>
+    /// <exception cref="ArgumentException"></exception>
+    public NitroKey1Encryption(string gameCode, DsiKeyStore keyStore)
     {
-        var encryption = new NitroKey1Encryption();
-        encryption.Initialize(gameCode, 2, 8, keys.BlowfishDsKey);
+        this.gameCode = gameCode ?? throw new ArgumentNullException(nameof(gameCode));
+        this.keyStore = keyStore ?? throw new ArgumentNullException(nameof(keyStore));
+
+        if (gameCode.Length != 4)
+            throw new ArgumentException("It must have length 4", nameof(gameCode));
+    }
+
+    public bool HasDisabledSecureArea(byte[] token)
+    {
+        ArgumentNullException.ThrowIfNull(token);
+        if (token.Length != 8)
+            throw new ArgumentException("Length must be 8", nameof(token));
+
+        var encryption = new NitroBlowfish();
+        encryption.Initialize(gameCode, 1, 8, keyStore.BlowfishDsKey);
+
+        byte[] decrypted = encryption.Encryption(false, token);
+        return Encoding.ASCII.GetString(decrypted) == DisableSecureAreaToken;
+    }
+
+    public byte[] GenerateEncryptedDisabledSecureAreaToken()
+    {
+        var encryption = new NitroBlowfish();
+        encryption.Initialize(gameCode, 1, 8, keyStore.BlowfishDsKey);
+
+        byte[] decrypted = Encoding.ASCII.GetBytes(DisableSecureAreaToken);
+        return encryption.Encryption(true, decrypted);
+    }
+
+    public byte[] DecryptSecureAreaId(byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        if (data.Length != 8)
+            throw new ArgumentException("Length must be 8", nameof(data));
+
+        var encryption = new NitroBlowfish();
+        encryption.Initialize(gameCode, 2, 8, keyStore.BlowfishDsKey);
         byte[] phase1 = encryption.Encryption(false, data);
 
-        encryption.Initialize(gameCode, 3, 8, keys.BlowfishDsKey);
+        encryption.Initialize(gameCode, 3, 8, keyStore.BlowfishDsKey);
         return encryption.Encryption(false, phase1);
     }
 
-    public static byte[] EncryptSecureAreaId(byte[] data, string gameCode, DsiKeyStore keys)
+    public byte[] EncryptSecureAreaId(byte[] data)
     {
-        var encryption = new NitroKey1Encryption();
-        encryption.Initialize(gameCode, 3, 8, keys.BlowfishDsKey);
+        ArgumentNullException.ThrowIfNull(data);
+        if (data.Length != 8)
+            throw new ArgumentException("Length must be 8", nameof(data));
+
+        var encryption = new NitroBlowfish();
+        encryption.Initialize(gameCode, 3, 8, keyStore.BlowfishDsKey);
         byte[] phase2 = encryption.Encryption(true, data);
 
-        encryption.Initialize(gameCode, 2, 8, keys.BlowfishDsKey);
+        encryption.Initialize(gameCode, 2, 8, keyStore.BlowfishDsKey);
         return encryption.Encryption(true, phase2);
     }
 
-    public static bool HasEncryptedArm9(DataStream arm9, ProgramInfo info, DsiKeyStore keys)
+    public bool HasEncryptedArm9(DataStream arm9)
     {
+        ArgumentNullException.ThrowIfNull(arm9);
+        if (arm9.Length < EncryptedSecureAreaLength)
+            throw new ArgumentException("ARM9 must be at least 2 KB", nameof(arm9));
+
         byte[] secureAreaId = new byte[8];
         arm9.Position = 0;
         arm9.Read(secureAreaId);
@@ -64,25 +118,21 @@ public class NitroKey1Encryption
             return false;
         }
 
-        byte[] decryptedSecureId = DecryptSecureAreaId(secureAreaId, info.GameCode, keys);
-        if (Encoding.ASCII.GetString(decryptedSecureId) == "encryObj") {
+        byte[] decryptedSecureId = DecryptSecureAreaId(secureAreaId);
+        if (Encoding.ASCII.GetString(decryptedSecureId) == SecureAreaId) {
             return true;
         }
 
-        throw new FormatException("Unknown AMR9 format");
+        return false; // like secure area filled with 0x00 to avoid it.
     }
 
-    public static DataStream EncryptArm9(DataStream arm9, string gameCode, DsiKeyStore keys)
+    public DataStream EncryptArm9(DataStream arm9)
     {
         ArgumentNullException.ThrowIfNull(arm9);
-        ArgumentNullException.ThrowIfNull(keys);
-        ArgumentNullException.ThrowIfNull(gameCode);
-        if (gameCode.Length != 4)
-            throw new ArgumentException("It must have length 4", nameof(gameCode));
         if (arm9.Length < EncryptedSecureAreaLength)
             throw new ArgumentException("ARM9 must be at least 2 KB", nameof(arm9));
 
-        var encryption = new NitroKey1Encryption();
+        var encryption = new NitroBlowfish();
         var output = new DataStream();
         arm9.WriteTo(output);
 
@@ -91,197 +141,17 @@ public class NitroKey1Encryption
 
         // Set the secure area ID (overwritten by BIOS so it's not in the game dumps).
         encryptedArea.Position = 0;
-        encryptedArea.Write(Encoding.ASCII.GetBytes("encryObj"), 0, 8);
+        encryptedArea.Write(Encoding.ASCII.GetBytes(SecureAreaId), 0, 8);
 
         // First pass encrypt the whole area
-        encryption.Initialize(gameCode, 3, 8, keys.BlowfishDsKey);
+        encryption.Initialize(gameCode, 3, 8, keyStore.BlowfishDsKey);
         encryption.Encryption(true, encryptedArea);
 
         // Second pass only re-encrypts the secure area ID
-        encryption.Initialize(gameCode, 2, 8, keys.BlowfishDsKey);
+        encryption.Initialize(gameCode, 2, 8, keyStore.BlowfishDsKey);
         using var secureAreaIdStream = new DataStream(encryptedArea, 0, 8);
         encryption.Encryption(true, secureAreaIdStream);
 
         return output;
     }
-
-    private void Initialize(string idCodeText, int level, int modulo, byte[] key)
-    {
-        Array.Copy(key, keyBuffer, key.Length);
-        uint[] keyCode = new uint[3];
-
-        byte[] idCodeBin = Encoding.ASCII.GetBytes(idCodeText);
-        uint idCode = BitConverter.ToUInt32(idCodeBin);
-        keyCode[0] = idCode;
-        keyCode[1] = idCode >> 1;
-        keyCode[2] = idCode << 1;
-
-        if (level >= 1) {
-            ApplyKeyCode(modulo, keyCode);
-        }
-
-        if (level >= 2) {
-            ApplyKeyCode(modulo, keyCode);
-        }
-
-        keyCode[1] <<= 1;
-        keyCode[2] >>= 1;
-
-        if (level >= 3) {
-            ApplyKeyCode(modulo, keyCode);
-        }
-    }
-
-    // public DataStream DecryptGameCart(DataStream arm9, ProgramInfo programInfo)
-    // {
-    //     byte[] dsKey = keys.BlowfishDsKey;
-    //
-    //     arm9.Position = 0;
-    //     var output = new DataStream();
-
-        // Level 1: decrypt header "secure area disable" token.
-        // InitKeyCode(programInfo.GameCode, 1, 8, dsKey);
-        // ulong disableToken = BitConverter.ToUInt64(Encoding.ASCII.GetBytes("NmMdOnly"));
-        // var outSecureDisable = Encryption64Bits(disableToken, true);
-        // var inSecureDisable = Encryption64Bits(outSecureDisable, false);
-
-        // byte[] secureAreaInfo = new byte[8];
-        // arm9.Read(secureAreaInfo);
-        // secureAreaInfo = System.Text.Encoding.ASCII.GetBytes("encryObj");
-
-        // Level 2: decrypt secure area info token (and encrypt cartridge commands)
-        // InitKeyCode(programInfo.GameCode, 2, 8, dsKey);
-
-        // byte[] test1 = { 0x1D, 0x9E, 0xBA, 0xC7, 0xBB, 0x0E, 0x9E, 0x6A };
-        // byte[] decrypted = Encryption64Bits(test1, false);
-        // var text = Encoding.ASCII.GetString(decrypted);
-        // byte[] test2 = Encryption64Bits(decrypted, true);
-
-        // var outObj = Encryption64Bits(BitConverter.ToUInt64(secureAreaInfo), true);
-        // var outObj2 = Encryption64Bits(outObj, false);
-        // var t = Encoding.ASCII.GetString(BitConverter.GetBytes(outObj2));
-
-        // Level 3: decrypt full secure area
-        // InitKeyCode(programInfo.GameCode, 3, 8, dsKey);
-
-        // arm9.Position = 0;
-        // using var secureAreaStream = new DataStream(arm9, 0, 2 * 1024);
-        // EncryptionStream(secureAreaStream, output, false);
-        //
-        // using var plainArm9 = new DataStream(arm9, 2 * 1024, arm9.Length - 2 * 1024);
-        // plainArm9.WriteTo(output);
-
-        // Level 1 with DSi key would encrypt cartridge commands.
-    //     return output;
-    // }
-
-    private void ApplyKeyCode(int modulo, uint[] keyCode)
-    {
-        uint GetMixValue(uint[] array, int bytePos)
-        {
-            uint val = 0;
-            for (int i = 3; i >= 0; i--) {
-                val <<= 8;
-
-                int pos = bytePos + i;
-                int bPos = pos / 4;
-                int bitPos = (pos % 4) * 8;
-                val |= (byte)(array[bPos] >> (24 - bitPos));
-            }
-
-            return val;
-        }
-
-        Encryption(true, ref keyCode[1], ref keyCode[2]);
-        Encryption(true, ref keyCode[0], ref keyCode[1]);
-
-        for (int i = 0; i <= 0x44; i += 4) {
-            uint xorValue = GetMixValue(keyCode, i % modulo);
-            uint value = GetUInt32(keyBuffer, i);
-            SetUInt32(keyBuffer, i, value ^ xorValue);
-        }
-
-        uint scratch0 = 0;
-        uint scratch1 = 0;
-        for (int i = 0; i <= 0x1040; i += 8) {
-            Encryption(true, ref scratch0, ref scratch1);
-            SetUInt32(keyBuffer, i, scratch1);
-            SetUInt32(keyBuffer, i + 4, scratch0);
-        }
-    }
-
-    private void Encryption(bool encrypt, ref uint data0, ref uint data1)
-    {
-        uint y = data0;
-        uint x = data1;
-
-        int iStart = encrypt ? 0 : 0x11;
-        int iEnd = encrypt ? 0x0F : 0x02;
-        int iDiff = encrypt ? 1 : -1;
-        for (int i = iStart; i != iEnd + iDiff; i += iDiff) {
-            uint z = GetKeyBuffer(i * 4) ^ x;
-            x = GetKeyBuffer(0x048 + (((z >> 24) & 0xFF) * 4));
-            x += GetKeyBuffer(0x448 + (((z >> 16) & 0xFF) * 4));
-            x ^= GetKeyBuffer(0x848 + (((z >> 8) & 0xFF) * 4));
-            x += GetKeyBuffer(0xC48 + (((z >> 0) & 0xFF) * 4));
-            x ^= y;
-            y = z;
-        }
-
-        uint xorX = GetKeyBuffer(encrypt ? 0x40 : 0x04);
-        data0 = x ^ xorX;
-
-        uint xorY = GetKeyBuffer(encrypt ? 0x44 : 0x00);
-        data1 = y ^ xorY;
-    }
-
-    private void Encryption(bool encrypt, DataStream stream)
-    {
-        var reader = new DataReader(stream);
-        var writer = new DataWriter(stream);
-
-        stream.Position = 0;
-        while (stream.Position + 8 <= stream.Length) {
-            uint data0 = reader.ReadUInt32();
-            uint data1 = reader.ReadUInt32();
-
-            Encryption(encrypt, ref data0, ref data1);
-
-            stream.Position -= 8;
-            writer.Write(data0);
-            writer.Write(data1);
-        }
-    }
-
-    private byte[] Encryption(bool encrypt, byte[] data)
-    {
-        byte[] output = new byte[data.Length];
-
-        using DataStream inputStream = DataStreamFactory.FromArray(data);
-        var reader = new DataReader(inputStream);
-
-        for (int i = 0; i + 8 <= data.Length; i += 8) {
-            uint data0 = reader.ReadUInt32();
-            uint data1 = reader.ReadUInt32();
-
-            Encryption(encrypt, ref data0, ref data1);
-
-            Array.Copy(BitConverter.GetBytes(data0), 0, output, i, 4);
-            Array.Copy(BitConverter.GetBytes(data1), 0, output, i + 4, 4);
-        }
-
-        return output;
-    }
-
-    private uint GetKeyBuffer(int pos) => GetUInt32(keyBuffer, pos);
-
-    private uint GetKeyBuffer(uint pos) => GetKeyBuffer((int)pos);
-
-    private void SetUInt32(byte[] buffer, int pos, uint value)
-    {
-        byte[] data = BitConverter.GetBytes(value);
-        Array.Copy(data, 0, buffer, pos, data.Length);
-    }
-
-    private uint GetUInt32(byte[] buffer, int pos) => BitConverter.ToUInt32(buffer, pos);
 }

--- a/src/Ekona/Security/NitroKey1Encryption.cs
+++ b/src/Ekona/Security/NitroKey1Encryption.cs
@@ -1,0 +1,287 @@
+// Copyright (c) 2022 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using SceneGate.Ekona.Containers.Rom;
+using Yarhl.IO;
+
+namespace SceneGate.Ekona.Security;
+
+/// <summary>
+/// Encrypt and decrypt with the DS KEY1 algorithm.
+/// </summary>
+public class NitroKey1Encryption
+{
+    private const int EncryptedSecureAreaLength = 2 * 1024;
+    private static readonly byte[] DestroyedSecureId = { 0xFF, 0xDE, 0xFF, 0xE7, 0xFF, 0xDE, 0xFF, 0xE7 };
+    private readonly byte[] keyBuffer = new byte[0x1048];
+
+    public static byte[] DecryptSecureAreaId(byte[] data, string gameCode, DsiKeyStore keys)
+    {
+        var encryption = new NitroKey1Encryption();
+        encryption.Initialize(gameCode, 2, 8, keys.BlowfishDsKey);
+        byte[] phase1 = encryption.Encryption(false, data);
+
+        encryption.Initialize(gameCode, 3, 8, keys.BlowfishDsKey);
+        return encryption.Encryption(false, phase1);
+    }
+
+    public static byte[] EncryptSecureAreaId(byte[] data, string gameCode, DsiKeyStore keys)
+    {
+        var encryption = new NitroKey1Encryption();
+        encryption.Initialize(gameCode, 3, 8, keys.BlowfishDsKey);
+        byte[] phase2 = encryption.Encryption(true, data);
+
+        encryption.Initialize(gameCode, 2, 8, keys.BlowfishDsKey);
+        return encryption.Encryption(true, phase2);
+    }
+
+    public static bool HasEncryptedArm9(DataStream arm9, ProgramInfo info, DsiKeyStore keys)
+    {
+        byte[] secureAreaId = new byte[8];
+        arm9.Position = 0;
+        arm9.Read(secureAreaId);
+        if (secureAreaId.SequenceEqual(DestroyedSecureId)) {
+            return false;
+        }
+
+        byte[] decryptedSecureId = DecryptSecureAreaId(secureAreaId, info.GameCode, keys);
+        if (Encoding.ASCII.GetString(decryptedSecureId) == "encryObj") {
+            return true;
+        }
+
+        throw new FormatException("Unknown AMR9 format");
+    }
+
+    public static DataStream EncryptArm9(DataStream arm9, string gameCode, DsiKeyStore keys)
+    {
+        ArgumentNullException.ThrowIfNull(arm9);
+        ArgumentNullException.ThrowIfNull(keys);
+        ArgumentNullException.ThrowIfNull(gameCode);
+        if (gameCode.Length != 4)
+            throw new ArgumentException("It must have length 4", nameof(gameCode));
+        if (arm9.Length < EncryptedSecureAreaLength)
+            throw new ArgumentException("ARM9 must be at least 2 KB", nameof(arm9));
+
+        var encryption = new NitroKey1Encryption();
+        var output = new DataStream();
+        arm9.WriteTo(output);
+
+        // Only the first 2 KB of the secure area are encrypted.
+        using var encryptedArea = new DataStream(output, 0, EncryptedSecureAreaLength);
+
+        // Set the secure area ID (overwritten by BIOS so it's not in the game dumps).
+        encryptedArea.Position = 0;
+        encryptedArea.Write(Encoding.ASCII.GetBytes("encryObj"), 0, 8);
+
+        // First pass encrypt the whole area
+        encryption.Initialize(gameCode, 3, 8, keys.BlowfishDsKey);
+        encryption.Encryption(true, encryptedArea);
+
+        // Second pass only re-encrypts the secure area ID
+        encryption.Initialize(gameCode, 2, 8, keys.BlowfishDsKey);
+        using var secureAreaIdStream = new DataStream(encryptedArea, 0, 8);
+        encryption.Encryption(true, secureAreaIdStream);
+
+        return output;
+    }
+
+    private void Initialize(string idCodeText, int level, int modulo, byte[] key)
+    {
+        Array.Copy(key, keyBuffer, key.Length);
+        uint[] keyCode = new uint[3];
+
+        byte[] idCodeBin = Encoding.ASCII.GetBytes(idCodeText);
+        uint idCode = BitConverter.ToUInt32(idCodeBin);
+        keyCode[0] = idCode;
+        keyCode[1] = idCode >> 1;
+        keyCode[2] = idCode << 1;
+
+        if (level >= 1) {
+            ApplyKeyCode(modulo, keyCode);
+        }
+
+        if (level >= 2) {
+            ApplyKeyCode(modulo, keyCode);
+        }
+
+        keyCode[1] <<= 1;
+        keyCode[2] >>= 1;
+
+        if (level >= 3) {
+            ApplyKeyCode(modulo, keyCode);
+        }
+    }
+
+    // public DataStream DecryptGameCart(DataStream arm9, ProgramInfo programInfo)
+    // {
+    //     byte[] dsKey = keys.BlowfishDsKey;
+    //
+    //     arm9.Position = 0;
+    //     var output = new DataStream();
+
+        // Level 1: decrypt header "secure area disable" token.
+        // InitKeyCode(programInfo.GameCode, 1, 8, dsKey);
+        // ulong disableToken = BitConverter.ToUInt64(Encoding.ASCII.GetBytes("NmMdOnly"));
+        // var outSecureDisable = Encryption64Bits(disableToken, true);
+        // var inSecureDisable = Encryption64Bits(outSecureDisable, false);
+
+        // byte[] secureAreaInfo = new byte[8];
+        // arm9.Read(secureAreaInfo);
+        // secureAreaInfo = System.Text.Encoding.ASCII.GetBytes("encryObj");
+
+        // Level 2: decrypt secure area info token (and encrypt cartridge commands)
+        // InitKeyCode(programInfo.GameCode, 2, 8, dsKey);
+
+        // byte[] test1 = { 0x1D, 0x9E, 0xBA, 0xC7, 0xBB, 0x0E, 0x9E, 0x6A };
+        // byte[] decrypted = Encryption64Bits(test1, false);
+        // var text = Encoding.ASCII.GetString(decrypted);
+        // byte[] test2 = Encryption64Bits(decrypted, true);
+
+        // var outObj = Encryption64Bits(BitConverter.ToUInt64(secureAreaInfo), true);
+        // var outObj2 = Encryption64Bits(outObj, false);
+        // var t = Encoding.ASCII.GetString(BitConverter.GetBytes(outObj2));
+
+        // Level 3: decrypt full secure area
+        // InitKeyCode(programInfo.GameCode, 3, 8, dsKey);
+
+        // arm9.Position = 0;
+        // using var secureAreaStream = new DataStream(arm9, 0, 2 * 1024);
+        // EncryptionStream(secureAreaStream, output, false);
+        //
+        // using var plainArm9 = new DataStream(arm9, 2 * 1024, arm9.Length - 2 * 1024);
+        // plainArm9.WriteTo(output);
+
+        // Level 1 with DSi key would encrypt cartridge commands.
+    //     return output;
+    // }
+
+    private void ApplyKeyCode(int modulo, uint[] keyCode)
+    {
+        uint GetMixValue(uint[] array, int bytePos)
+        {
+            uint val = 0;
+            for (int i = 3; i >= 0; i--) {
+                val <<= 8;
+
+                int pos = bytePos + i;
+                int bPos = pos / 4;
+                int bitPos = (pos % 4) * 8;
+                val |= (byte)(array[bPos] >> (24 - bitPos));
+            }
+
+            return val;
+        }
+
+        Encryption(true, ref keyCode[1], ref keyCode[2]);
+        Encryption(true, ref keyCode[0], ref keyCode[1]);
+
+        for (int i = 0; i <= 0x44; i += 4) {
+            uint xorValue = GetMixValue(keyCode, i % modulo);
+            uint value = GetUInt32(keyBuffer, i);
+            SetUInt32(keyBuffer, i, value ^ xorValue);
+        }
+
+        uint scratch0 = 0;
+        uint scratch1 = 0;
+        for (int i = 0; i <= 0x1040; i += 8) {
+            Encryption(true, ref scratch0, ref scratch1);
+            SetUInt32(keyBuffer, i, scratch1);
+            SetUInt32(keyBuffer, i + 4, scratch0);
+        }
+    }
+
+    private void Encryption(bool encrypt, ref uint data0, ref uint data1)
+    {
+        uint y = data0;
+        uint x = data1;
+
+        int iStart = encrypt ? 0 : 0x11;
+        int iEnd = encrypt ? 0x0F : 0x02;
+        int iDiff = encrypt ? 1 : -1;
+        for (int i = iStart; i != iEnd + iDiff; i += iDiff) {
+            uint z = GetKeyBuffer(i * 4) ^ x;
+            x = GetKeyBuffer(0x048 + (((z >> 24) & 0xFF) * 4));
+            x += GetKeyBuffer(0x448 + (((z >> 16) & 0xFF) * 4));
+            x ^= GetKeyBuffer(0x848 + (((z >> 8) & 0xFF) * 4));
+            x += GetKeyBuffer(0xC48 + (((z >> 0) & 0xFF) * 4));
+            x ^= y;
+            y = z;
+        }
+
+        uint xorX = GetKeyBuffer(encrypt ? 0x40 : 0x04);
+        data0 = x ^ xorX;
+
+        uint xorY = GetKeyBuffer(encrypt ? 0x44 : 0x00);
+        data1 = y ^ xorY;
+    }
+
+    private void Encryption(bool encrypt, DataStream stream)
+    {
+        var reader = new DataReader(stream);
+        var writer = new DataWriter(stream);
+
+        stream.Position = 0;
+        while (stream.Position + 8 <= stream.Length) {
+            uint data0 = reader.ReadUInt32();
+            uint data1 = reader.ReadUInt32();
+
+            Encryption(encrypt, ref data0, ref data1);
+
+            stream.Position -= 8;
+            writer.Write(data0);
+            writer.Write(data1);
+        }
+    }
+
+    private byte[] Encryption(bool encrypt, byte[] data)
+    {
+        byte[] output = new byte[data.Length];
+
+        using DataStream inputStream = DataStreamFactory.FromArray(data);
+        var reader = new DataReader(inputStream);
+
+        for (int i = 0; i + 8 <= data.Length; i += 8) {
+            uint data0 = reader.ReadUInt32();
+            uint data1 = reader.ReadUInt32();
+
+            Encryption(encrypt, ref data0, ref data1);
+
+            Array.Copy(BitConverter.GetBytes(data0), 0, output, i, 4);
+            Array.Copy(BitConverter.GetBytes(data1), 0, output, i + 4, 4);
+        }
+
+        return output;
+    }
+
+    private uint GetKeyBuffer(int pos) => GetUInt32(keyBuffer, pos);
+
+    private uint GetKeyBuffer(uint pos) => GetKeyBuffer((int)pos);
+
+    private void SetUInt32(byte[] buffer, int pos, uint value)
+    {
+        byte[] data = BitConverter.GetBytes(value);
+        Array.Copy(data, 0, buffer, pos, data.Length);
+    }
+
+    private uint GetUInt32(byte[] buffer, int pos) => BitConverter.ToUInt32(buffer, pos);
+}


### PR DESCRIPTION
### Description

- Implement DS KEY1 encryption based on Blowfish
- Implement decrypt/encrypt ARM9 (secure area) also known as "encrypted DS cartridge"
- Verify and re-generate the secure area CRC from the header.
- Verify and re-generate the phase 1 HMAC of the header.
- Verify and generate disable secure area token.
- Implement verify and generate "disable secure area" token from the DS header.
- Rename header hashes and related enums.
- Add a performance test for the encryption. It takes about 150 us (0.00015 sec) to encrypt or decrypt a 2 KB secure area.

### Example

To use the KEY1 encryption alone use the class `NitroBlowfish`:

```csharp
var blowfish = new NitroBlowfish();
blowfish.Initialize(gameCode, level, modulo, key);

uint data0, data1;
byte[] dataArray;
Stream dataStream;

blowfish.Decrypt(ref data0, ref data1); // or Encrypt()
byte[] output = blowfish.Decrypt(dataArray); // or Encrypt()
blowfish.Decrypt(dataStream); // or Encrypt()
```

To encrypt or decrypt the ARM9 use the class `NitroKey1Encryption`:

```csharp
var encryption = new NitroKey1Encryption(gameCode, keys);
bool isEncrypted = encryption.HasEncryptedArm9(arm9Stream); // false in game dumps
using DataStream encryptedArm9 = encryption.EncryptArm9(arm9Stream);
using DataStream decryptedArm9 = encryption.DecryptArm9(encryptedArm9);
```

To verify or generate the "disable secure area" token use the class `NitroKey1Encryption`:

```csharp
var encryption = new NitroKey1Encryption(gameCode, keys);
byte[] token = encryption.GenerateEncryptedDisabledSecureAreaToken();
encryption.HasDisabledSecureArea(token);
```