### PR TITLE
:sparkles: Deserialize and serialize DSi fields of ROM header

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "2.1.0",
+      "version": "2.2.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -14,7 +14,7 @@ on:
       - published
 
 env:
-  NET_SDK: '6.0.200'
+  NET_SDK: '6.0.202'
 
 jobs:
   build_main:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,9 +14,14 @@
     },
     "prettier.proseWrap": "always",
     "cSpell.words": [
+        "Agcb",
         "cref",
         "Ekona",
+        "ESRB",
         "HMAC",
+        "NAND",
+        "Pegi",
+        "SCFG",
         "WRAM"
     ],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,7 @@
     "cSpell.words": [
         "cref",
         "Ekona",
-        "HMAC"
+        "HMAC",
+        "WRAM"
     ],
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ekona [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat)](https://choosealicense.com/licenses/mit/) ![Build and release](https://github.com/SceneGate/Ekona/workflows/Build%20and%20release/badge.svg)
 
-[Yarhl](https://github.com/SceneGate/yarhl) plugin for DS common formats.
+[Yarhl](https://github.com/SceneGate/yarhl) plugin for DS and DSi formats.
 
 The library supports .NET 6.0 and above on Linux, Window and MacOS.
 
@@ -14,11 +14,15 @@ The library supports .NET 6.0 and above on Linux, Window and MacOS.
 
 _Encryption and decryption not supported yet._
 
-- DS cartridge filesystem: read and write
+- DS cartridge:
+  - Filesystem: read and write
   - Header: read and write, including extended header
-  - Banner and icon: read and write, including animated icons from DSi.
+  - Banner and icon: read and write.
   - HMAC validation and re-generation when keys are provided.
   - Signature validation when keys are provided.
+- DSi cartridge:
+  - Header: read and write
+  - Animated banner icons
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -12,17 +12,20 @@ The library supports .NET 6.0 and above on Linux, Window and MacOS.
 
 ## Supported formats
 
-_Encryption and decryption not supported yet._
-
 - DS cartridge:
   - Filesystem: read and write
   - Header: read and write, including extended header
   - Banner and icon: read and write.
+  - ARM9 secure area encryption and decryption.
   - HMAC validation and re-generation when keys are provided.
   - Signature validation when keys are provided.
 - DSi cartridge:
   - Header: read and write
   - Animated banner icons
+  - HMAC validation and re-generation when keys are provided.
+  - Signature validation when keys are provided.
+  - _arm9i, arm7i and digest generation not supported yet._
+  - _Modcrypt encryption and decryption not supported yet._
 
 ## Documentation
 

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -168,6 +168,7 @@ dotnet_diagnostic.CA1303.severity = none # We don't translate exception and log 
 dotnet_diagnostic.SA1009.severity = none # False positive due to nullables
 dotnet_diagnostic.SA1011.severity = none # False positive due to nullables
 dotnet_diagnostic.SA1101.severity = none # Do not force to prefix local calls with 'this'
+dotnet_diagnostic.SA1137.severity = none # False positive due to inline methods
 dotnet_diagnostic.SA1500.severity = none # Allow inline braces
 dotnet_diagnostic.SA1503.severity = suggestion # Braces can be omitted (guards can)
 dotnet_diagnostic.SA1633.severity = none # No XML-format header in source files

--- a/src/Ekona.Tests/Containers/Rom/Binary2NitroRomTests.cs
+++ b/src/Ekona.Tests/Containers/Rom/Binary2NitroRomTests.cs
@@ -133,7 +133,7 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
 
             generatedStream.Stream.Length.Should().Be(node.Stream!.Length);
 
-            // TODO: After implementing DSi fields
+            // TODO: After implementing DSi disgest, HMAC and armXi
             if (rom.Information.UnitCode == DeviceUnitKind.DS) {
                 generatedStream.Stream!.Compare(node.Stream).Should().BeTrue();
             }

--- a/src/Ekona.Tests/Containers/Rom/Binary2NitroRomTests.cs
+++ b/src/Ekona.Tests/Containers/Rom/Binary2NitroRomTests.cs
@@ -120,6 +120,15 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
                 programInfo.NitroProgramMac.IsNull.Should().BeTrue();
                 programInfo.NitroOverlaysMac.IsNull.Should().BeTrue();
                 programInfo.Signature.Status.Should().Be(HashStatus.Valid);
+
+                programInfo.DsiInfo.Arm9SecureMac.Status.Should().Be(HashStatus.Valid);
+                programInfo.DsiInfo.Arm7Mac.Status.Should().Be(HashStatus.Valid);
+                programInfo.DsiInfo.DigestMain.Status.Should().Be(HashStatus.Valid);
+
+                // TODO: After modcrypt implementation.
+                // programInfo.DsiInfo.Arm9iMac.Status.Should().Be(HashStatus.Valid)
+                // programInfo.DsiInfo.Arm7iMac.Status.Should().Be(HashStatus.Valid)
+                programInfo.DsiInfo.Arm9Mac.Status.Should().Be(HashStatus.Valid);
             }
         }
 
@@ -135,7 +144,7 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
 
             generatedStream.Stream.Length.Should().Be(node.Stream!.Length);
 
-            // TODO: After implementing DSi disgest, HMAC and armXi
+            // TODO: After implementing DSi disgest and armXi
             if (rom.Information.UnitCode == DeviceUnitKind.DS) {
                 generatedStream.Stream!.Compare(node.Stream).Should().BeTrue();
             }
@@ -182,13 +191,31 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
 
                 // Not regenerated but should keep it
                 newInfo.Signature.Hash.Should().BeEquivalentTo(originalInfo.Signature.Hash);
-                newInfo.Signature.Status.Should().Be(HashStatus.NotValidated); // not generated
+                newInfo.Signature.Status.Should().Be(HashStatus.NotValidated);
             }
 
             if (isDsi) {
                 // Not regenerated but should keep it
                 newInfo.Signature.Hash.Should().BeEquivalentTo(originalInfo.Signature.Hash);
-                newInfo.Signature.Status.Should().Be(HashStatus.NotValidated); // not generated
+                newInfo.Signature.Status.Should().Be(HashStatus.NotValidated);
+
+                newInfo.DsiInfo.Arm9SecureMac.Hash.Should().BeEquivalentTo(originalInfo.DsiInfo.Arm9SecureMac.Hash);
+                newInfo.DsiInfo.Arm9SecureMac.Status.Should().Be(HashStatus.NotValidated);
+
+                newInfo.DsiInfo.Arm7Mac.Hash.Should().BeEquivalentTo(originalInfo.DsiInfo.Arm7Mac.Hash);
+                newInfo.DsiInfo.Arm7Mac.Status.Should().Be(HashStatus.NotValidated);
+
+                newInfo.DsiInfo.DigestMain.Hash.Should().BeEquivalentTo(originalInfo.DsiInfo.DigestMain.Hash);
+                newInfo.DsiInfo.DigestMain.Status.Should().Be(HashStatus.NotValidated);
+
+                newInfo.DsiInfo.Arm9iMac.Hash.Should().BeEquivalentTo(originalInfo.DsiInfo.Arm9iMac.Hash);
+                newInfo.DsiInfo.Arm9iMac.Status.Should().Be(HashStatus.NotValidated);
+
+                newInfo.DsiInfo.Arm7iMac.Hash.Should().BeEquivalentTo(originalInfo.DsiInfo.Arm7iMac.Hash);
+                newInfo.DsiInfo.Arm7iMac.Status.Should().Be(HashStatus.NotValidated);
+
+                newInfo.DsiInfo.Arm9Mac.Hash.Should().BeEquivalentTo(originalInfo.DsiInfo.Arm9Mac.Hash);
+                newInfo.DsiInfo.Arm9Mac.Status.Should().Be(HashStatus.NotValidated);
             }
         }
 
@@ -227,13 +254,30 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
 
                 // Not regenerated but should keep it
                 newInfo.Signature.Hash.Should().BeEquivalentTo(originalInfo.Signature.Hash);
-                originalInfo.Signature.Status.Should().Be(HashStatus.NotValidated); // not generated
+                originalInfo.Signature.Status.Should().Be(HashStatus.NotValidated);
             }
 
             if (isDsi) {
                 // Not regenerated but should keep it
                 newInfo.Signature.Hash.Should().BeEquivalentTo(originalInfo.Signature.Hash);
-                originalInfo.Signature.Status.Should().Be(HashStatus.NotValidated); // not generated
+                originalInfo.Signature.Status.Should().Be(HashStatus.NotValidated);
+
+                newInfo.DsiInfo.Arm9SecureMac.Hash.Should().BeEquivalentTo(originalInfo.DsiInfo.Arm9SecureMac.Hash);
+                originalInfo.DsiInfo.Arm9SecureMac.Status.Should().Be(HashStatus.Generated);
+
+                newInfo.DsiInfo.Arm7Mac.Hash.Should().BeEquivalentTo(originalInfo.DsiInfo.Arm7Mac.Hash);
+                originalInfo.DsiInfo.Arm7Mac.Status.Should().Be(HashStatus.Generated);
+
+                newInfo.DsiInfo.DigestMain.Hash.Should().BeEquivalentTo(originalInfo.DsiInfo.DigestMain.Hash);
+                originalInfo.DsiInfo.DigestMain.Status.Should().Be(HashStatus.Generated);
+
+                // TODO: After modcrypt implementation.
+                // newInfo.DsiInfo.Arm9iMac.Hash.Should().BeEquivalentTo(originalInfo.DsiInfo.Arm9iMac.Hash)
+                // originalInfo.DsiInfo.Arm9iMac.Status.Should().Be(HashStatus.Generated)
+                // newInfo.DsiInfo.Arm7iMac.Hash.Should().BeEquivalentTo(originalInfo.DsiInfo.Arm7iMac.Hash)
+                // originalInfo.DsiInfo.Arm7iMac.Status.Should().Be(HashStatus.Generated)
+                newInfo.DsiInfo.Arm9Mac.Hash.Should().BeEquivalentTo(originalInfo.DsiInfo.Arm9Mac.Hash);
+                originalInfo.DsiInfo.Arm9Mac.Status.Should().Be(HashStatus.Generated);
             }
         }
     }

--- a/src/Ekona.Tests/Containers/Rom/Binary2RomHeaderTests.cs
+++ b/src/Ekona.Tests/Containers/Rom/Binary2RomHeaderTests.cs
@@ -102,6 +102,15 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
                 programInfo.Signature.Should().NotBeNull();
                 programInfo.Signature.Status.Should().Be(HashStatus.NotValidated);
             }
+
+            if (isDsi) {
+                programInfo.DsiInfo.Arm9SecureMac.Status.Should().Be(HashStatus.NotValidated);
+                programInfo.DsiInfo.Arm7Mac.Status.Should().Be(HashStatus.NotValidated);
+                programInfo.DsiInfo.DigestMain.Status.Should().Be(HashStatus.NotValidated);
+                programInfo.DsiInfo.Arm9iMac.Status.Should().Be(HashStatus.NotValidated);
+                programInfo.DsiInfo.Arm7iMac.Status.Should().Be(HashStatus.NotValidated);
+                programInfo.DsiInfo.Arm9Mac.Status.Should().Be(HashStatus.NotValidated);
+            }
         }
 
         [TestCaseSource(nameof(GetFiles))]

--- a/src/Ekona.Tests/Containers/Rom/Binary2RomHeaderTests.cs
+++ b/src/Ekona.Tests/Containers/Rom/Binary2RomHeaderTests.cs
@@ -116,11 +116,7 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
 
             var originalStream = new DataStream(node.Stream!, 0, header.SectionInfo.HeaderSize);
             generatedStream.Stream.Length.Should().Be(originalStream.Length);
-
-            // TODO: Enable after adding the DSi flags
-            if (header.ProgramInfo.UnitCode == DeviceUnitKind.DS) {
-                generatedStream.Stream.Compare(originalStream).Should().BeTrue();
-            }
+            generatedStream.Stream.Compare(originalStream).Should().BeTrue();
         }
 
         [TestCaseSource(nameof(GetFiles))]

--- a/src/Ekona/Containers/Rom/AgeRating.cs
+++ b/src/Ekona/Containers/Rom/AgeRating.cs
@@ -1,0 +1,41 @@
+// Copyright (c) 2022 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace SceneGate.Ekona.Containers.Rom;
+
+/// <summary>
+/// Age rating for a region.
+/// </summary>
+public class AgeRating
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether this rating applies or not.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the program is prohibited in the region.
+    /// </summary>
+    public bool Prohibited { get; set; }
+
+    /// <summary>
+    /// Gets or sets the minimal age for the program. The value meaning may vary per region.
+    /// </summary>
+    public int Age { get; set; }
+}

--- a/src/Ekona/Containers/Rom/Binary2NitroRom.cs
+++ b/src/Ekona/Containers/Rom/Binary2NitroRom.cs
@@ -299,6 +299,21 @@ namespace SceneGate.Ekona.Containers.Rom
                 var signer = new TwilightSigner(keyStore.PublicModulusRetailGames);
                 programInfo.Signature.Status = signer.VerifySignature(programInfo.Signature.Hash, reader.Stream);
             }
+
+            if (isDsi && keyStore.HMacKeyDSiGames is { Length: > 0 }) {
+                byte[] arm9EncryptedHash = hashGenerator.GenerateEncryptedArm9Hmac(encryptedArm9);
+                programInfo.DsiInfo.Arm9SecureMac.Validate(arm9EncryptedHash);
+
+                byte[] arm7Hash = hashGenerator.GenerateArm7Hmac(reader.Stream, header.SectionInfo);
+                programInfo.DsiInfo.Arm7Mac.Validate(arm7Hash);
+
+                byte[] digestHash = hashGenerator.GenerateDigestBlockHmac(reader.Stream, header.SectionInfo);
+                programInfo.DsiInfo.DigestMain.Validate(digestHash);
+
+                // TODO: After modcrypt implementation HMAC for ARM9i and ARM7i.
+                byte[] arm9Hash = hashGenerator.GenerateArm9NoSecureAreaHmac(reader.Stream, header.SectionInfo);
+                programInfo.DsiInfo.Arm9Mac.Validate(arm9Hash);
+            }
         }
 
         private struct FileAddress

--- a/src/Ekona/Containers/Rom/Binary2RomHeader.cs
+++ b/src/Ekona/Containers/Rom/Binary2RomHeader.cs
@@ -97,7 +97,22 @@ namespace SceneGate.Ekona.Containers.Rom
             header.ProgramInfo.CartridgeSize = ProgramInfo.MinimumCartridgeSize * (1 << reader.ReadByte());
             reader.Stream.Position += 7; // reserved
             header.ProgramInfo.DsiCryptoFlags = (DsiCryptoMode)reader.ReadByte();
-            header.ProgramInfo.Region = reader.ReadByte();
+
+            if (header.ProgramInfo.UnitCode == DeviceUnitKind.DS) {
+                byte region = reader.ReadByte();
+                header.ProgramInfo.Region = ProgramRegion.Normal;
+
+                if ((region & 0x80) != 0) {
+                    header.ProgramInfo.Region |= ProgramRegion.China;
+                }
+
+                if ((region & 0x40) != 0) {
+                    header.ProgramInfo.Region |= ProgramRegion.Korea;
+                }
+            } else {
+                header.ProgramInfo.DsiInfo.StartJumpKind = (ProgramStartJumpKind)reader.ReadByte();
+            }
+
             header.ProgramInfo.Version = reader.ReadByte();
             header.ProgramInfo.AutoStartFlag = reader.ReadByte();
 
@@ -202,7 +217,7 @@ namespace SceneGate.Ekona.Containers.Rom
             info.GlobalWramCntSettings = reader.ReadByte();
 
             // Pos: 0x1B0
-            info.Region = reader.ReadUInt32();
+            header.ProgramInfo.Region = (ProgramRegion)reader.ReadUInt32();
             info.AccessControl = reader.ReadUInt32();
             info.Arm7ScfgExt7Setting = reader.ReadUInt32();
             reader.Stream.Position += 4; // ProgramFeatures flags read with DS fields

--- a/src/Ekona/Containers/Rom/Binary2RomHeader.cs
+++ b/src/Ekona/Containers/Rom/Binary2RomHeader.cs
@@ -48,6 +48,11 @@ namespace SceneGate.Ekona.Containers.Rom
             var header = new RomHeader();
 
             ReadDsFields(reader, header);
+
+            if (header.ProgramInfo.UnitCode != DeviceUnitKind.DS) {
+                ReadDsiFields(reader, header);
+            }
+
             ValidateChecksums(reader.Stream, header.ProgramInfo);
 
             return header;
@@ -143,6 +148,107 @@ namespace SceneGate.Ekona.Containers.Rom
             // Pos: 0xF80
             reader.Stream.Position = 0xF80;
             header.ProgramInfo.Signature = reader.ReadSignatureSHA1RSA();
+        }
+
+        private static void ReadDsiFields(DataReader reader, RomHeader header)
+        {
+            DsiProgramInfo info = header.ProgramInfo.DsiInfo;
+            RomSectionInfo sections = header.SectionInfo;
+
+            // Pos: 0x180
+            reader.Stream.Position = 0x180;
+            info.GlobalMbkSettings = reader.ReadBytes(5 * 4);
+
+            // Pos: 0x194
+            info.LocalMbkArm9Settings = reader.ReadBytes(3 * 4);
+
+            // Pos: 0x1A0
+            info.LocalMbkArm7Settings = reader.ReadBytes(3 * 4);
+            info.GlobalMbk9Settings = reader.ReadInt24();
+            info.GlobalWramCntSettings = reader.ReadByte();
+
+            // Pos: 0x1B0
+            info.Region = reader.ReadUInt32();
+            info.AccessControl = reader.ReadUInt32();
+            info.Arm7ScfgExt7Setting = reader.ReadUInt32();
+            reader.Stream.Position += 4; // ProgramFeatures flags read with DS fields
+
+            // Pos: 0x1C0
+            sections.Arm9iOffset = reader.ReadUInt32();
+            reader.Stream.Position += 4; // reserved
+            info.Arm9iRamAddress = reader.ReadUInt32();
+            sections.Arm9iSize = reader.ReadUInt32();
+
+            // Pos: 0x1D0
+            sections.Arm7iOffset = reader.ReadUInt32();
+            info.SdDeviceListArm7RamAddress = reader.ReadUInt32();
+            info.Arm7iRamAddress = reader.ReadUInt32();
+            sections.Arm7iSize = reader.ReadUInt32();
+
+            // Pos: 0x1E0
+            sections.DigestNitroOffset = reader.ReadUInt32();
+            sections.DigestNitroLength = reader.ReadUInt32();
+            sections.DigestTwilightOffset = reader.ReadUInt32();
+            sections.DigestTwilightLength = reader.ReadUInt32();
+
+            // Pos: 0x1F0
+            sections.DigestSectorHashtableOffset = reader.ReadUInt32();
+            sections.DigestSectorHashtableLength = reader.ReadUInt32();
+            sections.DigestBlockHashtableOffset = reader.ReadUInt32();
+            sections.DigestBlockHashtableLength = reader.ReadUInt32();
+
+            // Pos: 0x200
+            sections.DigestSectorSize = reader.ReadUInt32();
+            sections.DigestBlockSectorCount = reader.ReadUInt32();
+            sections.BannerLength = reader.ReadUInt32();
+            info.SdShared200Length = reader.ReadByte();
+            info.SdShared201Length = reader.ReadByte();
+            info.EulaVersion = reader.ReadByte();
+            info.UseRatings = reader.ReadByte();
+
+            // Pos: 0x210
+            sections.DsiRomLength = reader.ReadUInt32();
+            info.SdShared202Length = reader.ReadByte();
+            info.SdShared203Length = reader.ReadByte();
+            info.SdShared204Length = reader.ReadByte();
+            info.SdShared205Length = reader.ReadByte();
+            info.Arm9iParametersTableOffset = reader.ReadUInt32();
+            info.Arm7iParametersTableOffset = reader.ReadUInt32();
+
+            // Pos: 0x220
+            sections.ModcryptArea1Offset = reader.ReadUInt32();
+            sections.ModcryptArea1Length = reader.ReadUInt32();
+            sections.ModcryptArea2Offset = reader.ReadUInt32();
+            sections.ModcryptArea2Length = reader.ReadUInt32();
+
+            // Pos: 0x230
+            info.TitleId = reader.ReadUInt64();
+            info.SdPublicSaveLength = reader.ReadUInt32();
+            info.SdPrivateSaveLength = reader.ReadUInt32();
+
+            // Pos: 0x2F0
+            reader.Stream.Position = 0x2F0;
+            info.AgeRatingCero = reader.ReadByte();
+            info.AgeRatingEsrb = reader.ReadByte();
+            reader.Stream.Position++; // reserved
+            info.AgeRatingUsk = reader.ReadByte();
+            info.AgeRatingPegiEurope = reader.ReadByte();
+            reader.Stream.Position++; // reserved
+            info.AgeRatingPegiPortugal = reader.ReadByte();
+            info.AgeRatingPegiUk = reader.ReadByte();
+            info.AgeRatingAgcb = reader.ReadByte();
+            info.AgeRatingGrb = reader.ReadByte();
+            reader.Stream.Position += 6; // reserved
+
+            // Pos: 0x300
+            info.Arm9SecureMac = reader.ReadHMACSHA1();
+            info.Arm7Mac = reader.ReadHMACSHA1();
+            info.DigestMain = reader.ReadHMACSHA1();
+            reader.Stream.Position += 0x14; // Banner HMAC already read with DS fields
+            info.Arm9iMac = reader.ReadHMACSHA1();
+            info.Arm7iMac = reader.ReadHMACSHA1();
+            reader.Stream.Position += 0x28; // HMAC for whitelist DS games
+            info.Arm9Mac = reader.ReadHMACSHA1();
         }
 
         private static void ValidateChecksums(DataStream stream, ProgramInfo info)

--- a/src/Ekona/Containers/Rom/DeviceUnitKind.cs
+++ b/src/Ekona/Containers/Rom/DeviceUnitKind.cs
@@ -27,15 +27,15 @@ public enum DeviceUnitKind
     /// <summary>
     /// DS only game.
     /// </summary>
-    DS,
+    DS = 0,
 
     /// <summary>
     /// DSi game compatible on DS units too.
     /// </summary>
-    DSiCompatible,
+    DSiEnhanced = 2,
 
     /// <summary>
     /// DSi exclusive game.
     /// </summary>
-    DSi,
+    DSiExclusive = 3,
 }

--- a/src/Ekona/Containers/Rom/DsiProgramInfo.cs
+++ b/src/Ekona/Containers/Rom/DsiProgramInfo.cs
@@ -41,11 +41,20 @@ public class DsiProgramInfo
     /// </summary>
     public LocalMemoryBankSettings[] LocalMemoryBanksArm7 { get; set; }
 
+    /// <summary>
+    /// Gets or sets the global memory bank 9 settings: WRAM slot write protect.
+    /// </summary>
     public int GlobalMbk9Settings { get; set; }
 
+    /// <summary>
+    /// Gets or sets the WRAMCNT register settings.
+    /// </summary>
     public byte GlobalWramCntSettings { get; set; }
 
-    public uint Region { get; set; } // todo: check other region field
+    /// <summary>
+    /// Gets or sets the program start jump kind.
+    /// </summary>
+    public ProgramStartJumpKind StartJumpKind { get; set; }
 
     public uint AccessControl { get; set; }
 

--- a/src/Ekona/Containers/Rom/DsiProgramInfo.cs
+++ b/src/Ekona/Containers/Rom/DsiProgramInfo.cs
@@ -1,4 +1,4 @@
-// Copyright(c) 2021 SceneGate
+// Copyright(c) 2022 SceneGate
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -26,11 +26,20 @@ namespace SceneGate.Ekona.Containers.Rom;
 /// </summary>
 public class DsiProgramInfo
 {
-    public byte[] GlobalMbkSettings { get; set; }
+    /// <summary>
+    /// Gets or sets the global memory banks settings (MBK 1 - 5) for the DSi extended memory.
+    /// </summary>
+    public GlobalMemoryBankSettings[] GlobalMemoryBanks { get; set; }
 
-    public byte[] LocalMbkArm9Settings { get; set; }
+    /// <summary>
+    /// Gets or sets the local memory banks settings for ARM9 (MBK 6 - 8) for the DSi extended memory.
+    /// </summary>
+    public LocalMemoryBankSettings[] LocalMemoryBanksArm9 { get; set; }
 
-    public byte[] LocalMbkArm7Settings { get; set; }
+    /// <summary>
+    /// Gets or sets the local memory banks settings for ARM7 (MBK 6 - 8) for the DSi extended memory.
+    /// </summary>
+    public LocalMemoryBankSettings[] LocalMemoryBanksArm7 { get; set; }
 
     public int GlobalMbk9Settings { get; set; }
 

--- a/src/Ekona/Containers/Rom/DsiProgramInfo.cs
+++ b/src/Ekona/Containers/Rom/DsiProgramInfo.cs
@@ -60,41 +60,90 @@ public class DsiProgramInfo
 
     public uint Arm7ScfgExt7Setting { get; set; }
 
+    /// <summary>
+    /// Gets or sets the start of the RAM address for the ARM9i program.
+    /// </summary>
     public uint Arm9iRamAddress { get; set; }
 
-    public uint SdDeviceListArm7RamAddress { get; set; }
+    /// <summary>
+    /// Gets or sets the SD/eMMC device list ARM7 RAM address.
+    /// 0x400 bytes initialized by the firmware.
+    /// </summary>
+    public uint StorageDeviceListArm7RamAddress { get; set; }
 
+    /// <summary>
+    /// Gets or sets the start of the RAM address for the ARM7i program.
+    /// </summary>
     public uint Arm7iRamAddress { get; set; }
 
-    public int SdShared200Length { get; set; }
+    /// <summary>
+    /// Gets or sets the length for the file in SD/eMMC "shared2/0000".
+    /// </summary>
+    public int StorageShared20Length { get; set; }
 
-    public int SdShared201Length { get; set; }
+    /// <summary>
+    /// Gets or sets the length for the file in SD/eMMC "shared2/0001".
+    /// </summary>
+    public int StorageShared21Length { get; set; }
 
+    /// <summary>
+    /// Gets or sets the version of the EULA agreement.
+    /// </summary>
     public byte EulaVersion { get; set; }
 
+    /// <summary>
+    /// Gets or sets the use ratings.
+    /// </summary>
     public byte UseRatings { get; set; }
 
-    public int SdShared202Length { get; set; }
+    /// <summary>
+    /// Gets or sets the length for the file in SD/eMMC "shared2/0002".
+    /// </summary>
+    public int StorageShared22Length { get; set; }
 
-    public int SdShared203Length { get; set; }
+    /// <summary>
+    /// Gets or sets the length for the file in SD/eMMC "shared2/0003".
+    /// </summary>
+    public int StorageShared23Length { get; set; }
 
-    public int SdShared204Length { get; set; }
+    /// <summary>
+    /// Gets or sets the length for the file in SD/eMMC "shared2/0004".
+    /// </summary>
+    public int StorageShared24Length { get; set; }
 
-    public int SdShared205Length { get; set; }
+    /// <summary>
+    /// Gets or sets the length for the file in SD/eMMC "shared2/0005".
+    /// </summary>
+    public int StorageShared25Length { get; set; }
 
+    /// <summary>
+    /// Gets or sets the offset in the ARM9i program to the code parameters.
+    /// </summary>
     public uint Arm9iParametersTableOffset { get; set; }
 
+    /// <summary>
+    /// Gets or sets the offset in the ARM7i program to the code parameters.
+    /// </summary>
     public uint Arm7iParametersTableOffset { get; set; }
 
     public int ModcryptArea1Target { get; set; }
 
     public int ModcryptArea2Target { get; set; }
 
+    /// <summary>
+    /// Gets or sets the title ID of the program (similar to 3DS).
+    /// </summary>
     public ulong TitleId { get; set; }
 
-    public uint SdPublicSaveLength { get; set; }
+    /// <summary>
+    /// Gets or sets the length of the "public.sav" file for DSiWare.
+    /// </summary>
+    public uint StoragePublicSaveLength { get; set; }
 
-    public uint SdPrivateSaveLength { get; set; }
+    /// <summary>
+    /// Gets or sets the length of the "private.sav" file for DSiWare.
+    /// </summary>
+    public uint StoragePrivateSaveLength { get; set; }
 
     public byte AgeRatingCero { get; set; }
 

--- a/src/Ekona/Containers/Rom/DsiProgramInfo.cs
+++ b/src/Ekona/Containers/Rom/DsiProgramInfo.cs
@@ -56,9 +56,15 @@ public class DsiProgramInfo
     /// </summary>
     public ProgramStartJumpKind StartJumpKind { get; set; }
 
-    public uint AccessControl { get; set; }
+    /// <summary>
+    /// Gets or sets the access control for DSi features.
+    /// </summary>
+    public TwilightAccessControl AccessControl { get; set; }
 
-    public uint Arm7ScfgExt7Setting { get; set; }
+    /// <summary>
+    /// Gets or sets some extended features of DSi ARM7 control register (SCFG).
+    /// </summary>
+    public ScfgExtendedFeaturesArm7 ScfgExtendedArm7 { get; set; }
 
     /// <summary>
     /// Gets or sets the start of the RAM address for the ARM9i program.
@@ -126,9 +132,15 @@ public class DsiProgramInfo
     /// </summary>
     public uint Arm7iParametersTableOffset { get; set; }
 
-    public int ModcryptArea1Target { get; set; }
+    /// <summary>
+    /// Gets or sets the first target area to have encryption modcrypt.
+    /// </summary>
+    public ModcryptTargetKind ModcryptArea1Target { get; set; }
 
-    public int ModcryptArea2Target { get; set; }
+    /// <summary>
+    /// Gets or sets the second target area to have encryption modcrypt.
+    /// </summary>
+    public ModcryptTargetKind ModcryptArea2Target { get; set; }
 
     /// <summary>
     /// Gets or sets the title ID of the program (similar to 3DS).
@@ -145,21 +157,45 @@ public class DsiProgramInfo
     /// </summary>
     public uint StoragePrivateSaveLength { get; set; }
 
-    public byte AgeRatingCero { get; set; }
+    /// <summary>
+    /// Gets or sets the age rating CERO (Japan).
+    /// </summary>
+    public AgeRating AgeRatingCero { get; set; }
 
-    public byte AgeRatingEsrb { get; set; }
+    /// <summary>
+    /// Gets or sets the age rating ESRB (US / Canada).
+    /// </summary>
+    public AgeRating AgeRatingEsrb { get; set; }
 
-    public byte AgeRatingUsk { get; set; }
+    /// <summary>
+    /// Gets or sets the age rating USK (Germany).
+    /// </summary>
+    public AgeRating AgeRatingUsk { get; set; }
 
-    public byte AgeRatingPegiEurope { get; set; }
+    /// <summary>
+    /// Gets or sets the age rating PEGI (Pan-Europe).
+    /// </summary>
+    public AgeRating AgeRatingPegiEurope { get; set; }
 
-    public byte AgeRatingPegiPortugal { get; set; }
+    /// <summary>
+    /// Gets or sets the age rating PEGI for Portugal.
+    /// </summary>
+    public AgeRating AgeRatingPegiPortugal { get; set; }
 
-    public byte AgeRatingPegiUk { get; set; }
+    /// <summary>
+    /// Gets or sets the age rating PEGI and BBFC (UK).
+    /// </summary>
+    public AgeRating AgeRatingPegiUk { get; set; }
 
-    public byte AgeRatingAgcb { get; set; }
+    /// <summary>
+    /// Gets or sets the age rating AGCB (Australia).
+    /// </summary>
+    public AgeRating AgeRatingAgcb { get; set; }
 
-    public byte AgeRatingGrb { get; set; }
+    /// <summary>
+    /// Gets or sets the age rating GRB (South Korea).
+    /// </summary>
+    public AgeRating AgeRatingGrb { get; set; }
 
     public HashInfo Arm9SecureMac { get; set; }
 

--- a/src/Ekona/Containers/Rom/DsiProgramInfo.cs
+++ b/src/Ekona/Containers/Rom/DsiProgramInfo.cs
@@ -1,0 +1,108 @@
+// Copyright(c) 2021 SceneGate
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using SceneGate.Ekona.Security;
+
+namespace SceneGate.Ekona.Containers.Rom;
+
+/// <summary>
+/// Information of DSi programs.
+/// </summary>
+public class DsiProgramInfo
+{
+    public byte[] GlobalMbkSettings { get; set; }
+
+    public byte[] LocalMbkArm9Settings { get; set; }
+
+    public byte[] LocalMbkArm7Settings { get; set; }
+
+    public int GlobalMbk9Settings { get; set; }
+
+    public byte GlobalWramCntSettings { get; set; }
+
+    public uint Region { get; set; } // todo: check other region field
+
+    public uint AccessControl { get; set; }
+
+    public uint Arm7ScfgExt7Setting { get; set; }
+
+    public uint Arm9iRamAddress { get; set; }
+
+    public uint SdDeviceListArm7RamAddress { get; set; }
+
+    public uint Arm7iRamAddress { get; set; }
+
+    public int SdShared200Length { get; set; }
+
+    public int SdShared201Length { get; set; }
+
+    public byte EulaVersion { get; set; }
+
+    public byte UseRatings { get; set; }
+
+    public int SdShared202Length { get; set; }
+
+    public int SdShared203Length { get; set; }
+
+    public int SdShared204Length { get; set; }
+
+    public int SdShared205Length { get; set; }
+
+    public uint Arm9iParametersTableOffset { get; set; }
+
+    public uint Arm7iParametersTableOffset { get; set; }
+
+    public int ModcryptArea1Target { get; set; }
+
+    public int ModcryptArea2Target { get; set; }
+
+    public ulong TitleId { get; set; }
+
+    public uint SdPublicSaveLength { get; set; }
+
+    public uint SdPrivateSaveLength { get; set; }
+
+    public byte AgeRatingCero { get; set; }
+
+    public byte AgeRatingEsrb { get; set; }
+
+    public byte AgeRatingUsk { get; set; }
+
+    public byte AgeRatingPegiEurope { get; set; }
+
+    public byte AgeRatingPegiPortugal { get; set; }
+
+    public byte AgeRatingPegiUk { get; set; }
+
+    public byte AgeRatingAgcb { get; set; }
+
+    public byte AgeRatingGrb { get; set; }
+
+    public HashInfo Arm9SecureMac { get; set; }
+
+    public HashInfo Arm7Mac { get; set; }
+
+    public HashInfo DigestMain { get; set; }
+
+    public HashInfo Arm9iMac { get; set; }
+
+    public HashInfo Arm7iMac { get; set; }
+
+    public HashInfo Arm9Mac { get; set; }
+}

--- a/src/Ekona/Containers/Rom/DsiProgramInfo.cs
+++ b/src/Ekona/Containers/Rom/DsiProgramInfo.cs
@@ -197,15 +197,33 @@ public class DsiProgramInfo
     /// </summary>
     public AgeRating AgeRatingGrb { get; set; }
 
+    /// <summary>
+    /// Gets or sets the SHA1-HMAC of the ARM9 with encrypted secure area.
+    /// </summary>
     public HashInfo Arm9SecureMac { get; set; }
 
+    /// <summary>
+    /// Gets or sets the SHA1-HMAC of the ARM7.
+    /// </summary>
     public HashInfo Arm7Mac { get; set; }
 
+    /// <summary>
+    /// Gets or sets the SHA1-HMAC of digest block data.
+    /// </summary>
     public HashInfo DigestMain { get; set; }
 
+    /// <summary>
+    /// Gets or sets the SHA1-HMAC of the ARM9i program decrypted.
+    /// </summary>
     public HashInfo Arm9iMac { get; set; }
 
+    /// <summary>
+    /// Gets or sets the SHA1-HMAC of the ARM7i program decrypted.
+    /// </summary>
     public HashInfo Arm7iMac { get; set; }
 
+    /// <summary>
+    /// Gets or sets the SHA1-HMAC of the ARM9 program without secure area.
+    /// </summary>
     public HashInfo Arm9Mac { get; set; }
 }

--- a/src/Ekona/Containers/Rom/GlobalMemoryBankSettings.cs
+++ b/src/Ekona/Containers/Rom/GlobalMemoryBankSettings.cs
@@ -1,0 +1,50 @@
+// Copyright(c) 2022 SceneGate
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace SceneGate.Ekona.Containers.Rom;
+
+/// <summary>
+/// DSi extended memory global memory bank settings (MBK 1 to 5).
+/// </summary>
+public class GlobalMemoryBankSettings
+{
+    /// <summary>
+    /// Gets or sets the processor reserved for this memory.
+    /// </summary>
+    /// <remarks>
+    /// For MBK1 only ARM9 or ARM7.
+    /// For MBK2-3: also DSP for code.
+    /// For MBK4-5: also DSP for data.
+    /// </remarks>
+    public MemoryBankProcessor Processor { get; set; }
+
+    /// <summary>
+    /// Gets or sets the offset slot in blocks.
+    /// </summary>
+    /// <remarks>
+    /// For MBK1: 64 KB units.
+    /// For MBK2-5: 32 KB units.
+    /// </remarks>
+    public byte OffsetSlot { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this memory bank is enabled.
+    /// </summary>
+    public bool Enabled { get; set; }
+}

--- a/src/Ekona/Containers/Rom/LocalMemoryBankSettings.cs
+++ b/src/Ekona/Containers/Rom/LocalMemoryBankSettings.cs
@@ -1,0 +1,52 @@
+// Copyright(c) 2022 SceneGate
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace SceneGate.Ekona.Containers.Rom;
+
+/// <summary>
+/// DSi extended memory local (to a processor) memory bank settings (MBK 6 to 8).
+/// </summary>
+public class LocalMemoryBankSettings
+{
+    /// <summary>
+    /// Gets or sets the start address slot.
+    /// </summary>
+    /// <remarks>
+    /// Final address is: 0x03000000 + value * (0x010000 for MBK6 or 0x8000 for 7-8).
+    /// </remarks>
+    public int StartAddressSlot { get; set; }
+
+    /// <summary>
+    /// Gets or sets the image size kind.
+    /// </summary>
+    /// <remarks>
+    /// According to existing research:
+    /// MBK6: 0 or 1 = 64 KB /slot0, 2 = 128 KB / slot0-2, 3 = 256 KB / slot0-3
+    /// MBK7-8: 0 = 32 KB / slot0, 1 = 64 KB / slot0-1, 2 = 128 KB / slot0-3, 3 = 256 KB / slot0-7
+    /// </remarks>
+    public int ImageSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets the end address slot.
+    /// </summary>
+    /// <remarks>
+    /// Final address is: 0x03000000 + value * (0x010000 for MBK6 or 0x8000 for 7-8) - 1.
+    /// </remarks>
+    public int EndAddressSlot { get; set; }
+}

--- a/src/Ekona/Containers/Rom/LocalMemoryBankSettings.cs
+++ b/src/Ekona/Containers/Rom/LocalMemoryBankSettings.cs
@@ -38,7 +38,7 @@ public class LocalMemoryBankSettings
     /// <remarks>
     /// According to existing research:
     /// MBK6: 0 or 1 = 64 KB /slot0, 2 = 128 KB / slot0-2, 3 = 256 KB / slot0-3
-    /// MBK7-8: 0 = 32 KB / slot0, 1 = 64 KB / slot0-1, 2 = 128 KB / slot0-3, 3 = 256 KB / slot0-7
+    /// MBK7-8: 0 = 32 KB / slot0, 1 = 64 KB / slot0-1, 2 = 128 KB / slot0-3, 3 = 256 KB / slot0-7.
     /// </remarks>
     public int ImageSize { get; set; }
 

--- a/src/Ekona/Containers/Rom/MemoryBankProcessor.cs
+++ b/src/Ekona/Containers/Rom/MemoryBankProcessor.cs
@@ -1,0 +1,46 @@
+// Copyright(c) 2022 SceneGate
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace SceneGate.Ekona.Containers.Rom;
+
+/// <summary>
+/// Gets or sets the processor assigned to a memory bank.
+/// </summary>
+public enum MemoryBankProcessor
+{
+    /// <summary>
+    /// ARM9 processor.
+    /// </summary>
+    Arm9 = 0,
+
+    /// <summary>
+    /// ARM7 processor.
+    /// </summary>
+    Arm7 = 1,
+
+    /// <summary>
+    /// DSP for value 2 (code?).
+    /// </summary>
+    Dsp2 = 2,
+
+    /// <summary>
+    /// DSP for value 3 (data?).
+    /// </summary>
+    Dsp3 = 3,
+}

--- a/src/Ekona/Containers/Rom/ModcryptTargetKind.cs
+++ b/src/Ekona/Containers/Rom/ModcryptTargetKind.cs
@@ -1,0 +1,56 @@
+// Copyright (c) 2022 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace SceneGate.Ekona.Containers.Rom;
+
+/// <summary>
+/// Target area to modcrypt.
+/// </summary>
+public enum ModcryptTargetKind
+{
+    /// <summary>
+    /// No area have modcrypt.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// ARM9 program.
+    /// </summary>
+    Arm9,
+
+    /// <summary>
+    /// ARM7 program.
+    /// </summary>
+    Arm7,
+
+    /// <summary>
+    /// ARM9i (DSi) program.
+    /// </summary>
+    Arm9i,
+
+    /// <summary>
+    /// ARM7i (DSi) program.
+    /// </summary>
+    Arm7i,
+
+    /// <summary>
+    /// Unknown area.
+    /// </summary>
+    Unknown,
+}

--- a/src/Ekona/Containers/Rom/NitroRom2Binary.cs
+++ b/src/Ekona/Containers/Rom/NitroRom2Binary.cs
@@ -206,6 +206,21 @@ public class NitroRom2Binary :
             programInfo.BannerMac.ChangeHash(bannerHash);
         }
 
+        if (isDsi && keyStore.HMacKeyDSiGames is { Length: > 0 }) {
+            byte[] arm9EncryptedHash = hashGenerator.GenerateEncryptedArm9Hmac(encryptedArm9);
+            programInfo.DsiInfo.Arm9SecureMac.ChangeHash(arm9EncryptedHash);
+
+            byte[] arm7Hash = hashGenerator.GenerateArm7Hmac(writer.Stream, sectionInfo);
+            programInfo.DsiInfo.Arm7Mac.ChangeHash(arm7Hash);
+
+            byte[] digestHash = hashGenerator.GenerateDigestBlockHmac(writer.Stream, sectionInfo);
+            programInfo.DsiInfo.DigestMain.ChangeHash(digestHash);
+
+            // TODO: After modcrypt implementation HMAC for ARM9i and ARM7i.
+            byte[] arm9Hash = hashGenerator.GenerateArm9NoSecureAreaHmac(writer.Stream, sectionInfo);
+            programInfo.DsiInfo.Arm9Mac.ChangeHash(arm9Hash);
+        }
+
         // While we could add the code to sign the data with a provided private key...
         // In practice it won't ever happen that we know the actual private key.
         // We could modify the NAND with our own public/private key but at that point

--- a/src/Ekona/Containers/Rom/ProgramInfo.cs
+++ b/src/Ekona/Containers/Rom/ProgramInfo.cs
@@ -71,7 +71,7 @@ namespace SceneGate.Ekona.Containers.Rom
         /// <summary>
         /// Gets or sets the supported region.
         /// </summary>
-        public ProgramRegion Region { get; set; }
+        public ProgramRegions Region { get; set; }
 
         /// <summary>
         /// Gets or sets the version of the program.

--- a/src/Ekona/Containers/Rom/ProgramInfo.cs
+++ b/src/Ekona/Containers/Rom/ProgramInfo.cs
@@ -235,6 +235,11 @@ namespace SceneGate.Ekona.Containers.Rom
         public HashInfo Signature { get; set; }
 
         /// <summary>
+        /// Gets or sets the information exclusive to DSi programs.
+        /// </summary>
+        public DsiProgramInfo DsiInfo { get; set; } = new DsiProgramInfo();
+
+        /// <summary>
         /// Gets or sets the program code (arm9) parameters.
         /// </summary>
         public NitroProgramCodeParameters ProgramCodeParameters { get; set; } = new NitroProgramCodeParameters();

--- a/src/Ekona/Containers/Rom/ProgramInfo.cs
+++ b/src/Ekona/Containers/Rom/ProgramInfo.cs
@@ -69,9 +69,9 @@ namespace SceneGate.Ekona.Containers.Rom
         public DsiCryptoMode DsiCryptoFlags { get; set; }
 
         /// <summary>
-        /// Gets or sets the special game region.
+        /// Gets or sets the supported region.
         /// </summary>
-        public byte Region { get; set; }
+        public ProgramRegion Region { get; set; }
 
         /// <summary>
         /// Gets or sets the version of the program.

--- a/src/Ekona/Containers/Rom/ProgramRegion.cs
+++ b/src/Ekona/Containers/Rom/ProgramRegion.cs
@@ -1,0 +1,69 @@
+// Copyright (c) 2022 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using System;
+
+namespace SceneGate.Ekona.Containers.Rom;
+
+/// <summary>
+/// Supported regions for the program.
+/// </summary>
+[Flags]
+public enum ProgramRegion : uint
+{
+    /// <summary>
+    /// Typical Nintendo supported regions (DS only).
+    /// </summary>
+    Normal = 0,
+
+    /// <summary>
+    /// Japan region (DSi only).
+    /// </summary>
+    Japan = 1 << 0,
+
+    /// <summary>
+    /// USA region (DSi only).
+    /// </summary>
+    Usa = 1 << 1,
+
+    /// <summary>
+    /// Europe region (DSi only).
+    /// </summary>
+    Europe = 1 << 2,
+
+    /// <summary>
+    /// Australia region (DSi only).
+    /// </summary>
+    Australia = 1 << 3,
+
+    /// <summary>
+    /// China region.
+    /// </summary>
+    China = 1 << 4,
+
+    /// <summary>
+    /// Korea region.
+    /// </summary>
+    Korea = 1 << 5,
+
+    /// <summary>
+    /// Region free, support on all possible regions.
+    /// </summary>
+    RegionFree = 0xFFFFFFFF,
+}

--- a/src/Ekona/Containers/Rom/ProgramRegions.cs
+++ b/src/Ekona/Containers/Rom/ProgramRegions.cs
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SceneGate.Ekona.Containers.Rom;
 
@@ -25,12 +26,14 @@ namespace SceneGate.Ekona.Containers.Rom;
 /// Supported regions for the program.
 /// </summary>
 [Flags]
-public enum ProgramRegion : uint
+[SuppressMessage("", "S4070", Justification = "RegionFree is a combination of every possible bit")]
+public enum ProgramRegions : uint
 {
     /// <summary>
-    /// Typical Nintendo supported regions (DS only).
+    /// Typical Nintendo supported regions for DS.
     /// </summary>
-    Normal = 0,
+    [SuppressMessage("", "S2346", Justification = "In this context makes more sense than None.")]
+    NitroBase = 0,
 
     /// <summary>
     /// Japan region (DSi only).

--- a/src/Ekona/Containers/Rom/ProgramStartJumpKind.cs
+++ b/src/Ekona/Containers/Rom/ProgramStartJumpKind.cs
@@ -1,0 +1,36 @@
+// Copyright (c) 2022 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace SceneGate.Ekona.Containers.Rom;
+
+/// <summary>
+/// The kind of program start jump at launch.
+/// </summary>
+public enum ProgramStartJumpKind
+{
+    /// <summary>
+    /// Normal jump copying header in the RAM.
+    /// </summary>
+    Normal = 0,
+
+    /// <summary>
+    /// Special / temporary launch used for the system menu.
+    /// </summary>
+    SystemMenu = 1,
+}

--- a/src/Ekona/Containers/Rom/RomHeader2Binary.cs
+++ b/src/Ekona/Containers/Rom/RomHeader2Binary.cs
@@ -70,6 +70,133 @@ public class RomHeader2Binary :
         return binary;
     }
 
+    private static void WriteDsiFields(DataWriter writer, RomHeader source)
+    {
+        DsiProgramInfo info = source.ProgramInfo.DsiInfo;
+        RomSectionInfo sections = source.SectionInfo;
+
+        writer.Stream.Position = 0x180;
+        WriteGlobalMemoryBankSettings(writer, info.GlobalMemoryBanks);
+        WriteLocalMemoryBankSettings(writer, info.LocalMemoryBanksArm9);
+        WriteLocalMemoryBankSettings(writer, info.LocalMemoryBanksArm7);
+        writer.Write(info.GlobalMbk9Settings | (info.GlobalWramCntSettings << 24));
+
+        writer.Write((uint)source.ProgramInfo.Region);
+        writer.Write(info.AccessControl);
+        writer.Write(info.Arm7ScfgExt7Setting);
+        writer.Stream.Position += 4; // ProgramFeatures written with DS fields
+
+        writer.Write(sections.Arm9iOffset);
+        writer.Write(0);
+        writer.Write(info.Arm9iRamAddress);
+        writer.Write(sections.Arm9iSize);
+        writer.Write(sections.Arm7iOffset);
+        writer.Write(info.StorageDeviceListArm7RamAddress);
+        writer.Write(info.Arm7iRamAddress);
+        writer.Write(sections.Arm7iSize);
+
+        writer.Write(sections.DigestNitroOffset);
+        writer.Write(sections.DigestNitroLength);
+        writer.Write(sections.DigestTwilightOffset);
+        writer.Write(sections.DigestTwilightLength);
+        writer.Write(sections.DigestSectorHashtableOffset);
+        writer.Write(sections.DigestSectorHashtableLength);
+        writer.Write(sections.DigestBlockHashtableOffset);
+        writer.Write(sections.DigestBlockHashtableLength);
+        writer.Write(sections.DigestSectorSize);
+        writer.Write(sections.DigestBlockSectorCount);
+
+        writer.Write(sections.BannerLength);
+        writer.Write((byte)info.StorageShared20Length);
+        writer.Write((byte)info.StorageShared21Length);
+        writer.Write(info.EulaVersion);
+        writer.Write(info.UseRatings);
+        writer.Write(sections.DsiRomLength);
+        writer.Write((byte)info.StorageShared22Length);
+        writer.Write((byte)info.StorageShared23Length);
+        writer.Write((byte)info.StorageShared24Length);
+        writer.Write((byte)info.StorageShared25Length);
+        writer.Write(info.Arm9iParametersTableOffset);
+        writer.Write(info.Arm7iParametersTableOffset);
+
+        writer.Write(sections.ModcryptArea1Offset);
+        writer.Write(sections.ModcryptArea1Length);
+        writer.Write(sections.ModcryptArea2Offset);
+        writer.Write(sections.ModcryptArea2Length);
+
+        writer.Write(info.TitleId);
+        writer.Write(info.StoragePublicSaveLength);
+        writer.Write(info.StoragePrivateSaveLength);
+
+        writer.Stream.Position = 0x2F0;
+        writer.Write(info.AgeRatingCero);
+        writer.Write(info.AgeRatingEsrb);
+        writer.Write((byte)0);
+        writer.Write(info.AgeRatingUsk);
+        writer.Write(info.AgeRatingPegiEurope);
+        writer.Write((byte)0);
+        writer.Write(info.AgeRatingPegiPortugal);
+        writer.Write(info.AgeRatingPegiUk);
+        writer.Write(info.AgeRatingAgcb);
+        writer.Write(info.AgeRatingGrb);
+
+        writer.Stream.Position = 0x300;
+        writer.Write(info.Arm9SecureMac.Hash);
+        writer.Write(info.Arm7Mac.Hash);
+        writer.Write(info.DigestMain.Hash);
+        writer.Stream.Position += 0x14; // Banner HMAC read with DS fields
+        writer.Write(info.Arm9iMac.Hash);
+        writer.Write(info.Arm7iMac.Hash);
+        writer.Stream.Position += 0x28; // DS whitelist macs
+        writer.Write(info.Arm9Mac.Hash);
+    }
+
+    private static void WriteGlobalMemoryBankSettings(DataWriter writer, GlobalMemoryBankSettings[] settings)
+    {
+        if (settings is not { Length: 5 * 4 }) {
+            throw new FormatException("Expecting 20 global memory bank settings");
+        }
+
+        for (int i = 0; i < settings.Length; i++) {
+            var setting = settings[i];
+            int maxProcessor = (i == 0) ? 1 : 3;
+            int maxSlot = (i == 0) ? 3 : 7;
+            if ((int)setting.Processor > maxProcessor || setting.OffsetSlot > maxSlot) {
+                throw new ArgumentException($"Invalid global memory bank setting for {i}");
+            }
+
+            int data = (int)setting.Processor;
+            data |= setting.OffsetSlot << 2;
+            data |= (setting.Enabled ? 1 : 0) << 7;
+            writer.Write((byte)data);
+        }
+    }
+
+    private static void WriteLocalMemoryBankSettings(DataWriter writer, LocalMemoryBankSettings[] settings)
+    {
+        if (settings is not { Length: 3 }) {
+            throw new FormatException("Expecting 3 local memory bank settings");
+        }
+
+        uint mbk6 = 0;
+        mbk6 |= (uint)(settings[0].StartAddressSlot << 4);
+        mbk6 |= (uint)(settings[0].ImageSize << 12);
+        mbk6 |= (uint)(settings[0].EndAddressSlot << 20);
+        writer.Write(mbk6);
+
+        for (int i = 0; i < 2; i++) {
+            var setting = settings[i + 1];
+            if (setting.StartAddressSlot > 511 || setting.ImageSize > 3 || setting.EndAddressSlot > 1023) {
+                throw new ArgumentException($"Invalid local memory bank setting for {i}");
+            }
+
+            uint data = (uint)(setting.StartAddressSlot << 3);
+            data |= (uint)(setting.ImageSize << 12);
+            data |= (uint)(setting.EndAddressSlot << 19);
+            writer.Write(data);
+        }
+    }
+
     private void WriteDsFields(DataWriter writer, RomHeader source)
     {
         writer.Write(source.ProgramInfo.GameTitle, 12, nullTerminator: false);
@@ -86,11 +213,11 @@ public class RomHeader2Binary :
 
         if (source.ProgramInfo.UnitCode == DeviceUnitKind.DS) {
             byte region = 0;
-            if (source.ProgramInfo.Region.HasFlag(ProgramRegion.China)) {
+            if (source.ProgramInfo.Region.HasFlag(ProgramRegions.China)) {
                 region |= 0x80;
             }
 
-            if (source.ProgramInfo.Region.HasFlag(ProgramRegion.Korea)) {
+            if (source.ProgramInfo.Region.HasFlag(ProgramRegions.Korea)) {
                 region |= 0x40;
             }
 
@@ -185,132 +312,5 @@ public class RomHeader2Binary :
         }
 
         writer.WriteUntilLength(0, source.SectionInfo.HeaderSize);
-    }
-
-    private static void WriteDsiFields(DataWriter writer, RomHeader source)
-    {
-        DsiProgramInfo info = source.ProgramInfo.DsiInfo;
-        RomSectionInfo sections = source.SectionInfo;
-
-        writer.Stream.Position = 0x180;
-        WriteGlobalMemoryBankSettings(writer, info.GlobalMemoryBanks);
-        WriteLocalMemoryBankSettings(writer, info.LocalMemoryBanksArm9);
-        WriteLocalMemoryBankSettings(writer, info.LocalMemoryBanksArm7);
-        writer.Write(info.GlobalMbk9Settings | (info.GlobalWramCntSettings << 24));
-
-        writer.Write((uint)source.ProgramInfo.Region);
-        writer.Write(info.AccessControl);
-        writer.Write(info.Arm7ScfgExt7Setting);
-        writer.Stream.Position += 4; // ProgramFeatures written with DS fields
-
-        writer.Write(sections.Arm9iOffset);
-        writer.Write(0);
-        writer.Write(info.Arm9iRamAddress);
-        writer.Write(sections.Arm9iSize);
-        writer.Write(sections.Arm7iOffset);
-        writer.Write(info.SdDeviceListArm7RamAddress);
-        writer.Write(info.Arm7iRamAddress);
-        writer.Write(sections.Arm7iSize);
-
-        writer.Write(sections.DigestNitroOffset);
-        writer.Write(sections.DigestNitroLength);
-        writer.Write(sections.DigestTwilightOffset);
-        writer.Write(sections.DigestTwilightLength);
-        writer.Write(sections.DigestSectorHashtableOffset);
-        writer.Write(sections.DigestSectorHashtableLength);
-        writer.Write(sections.DigestBlockHashtableOffset);
-        writer.Write(sections.DigestBlockHashtableLength);
-        writer.Write(sections.DigestSectorSize);
-        writer.Write(sections.DigestBlockSectorCount);
-
-        writer.Write(sections.BannerLength);
-        writer.Write((byte)info.SdShared200Length);
-        writer.Write((byte)info.SdShared201Length);
-        writer.Write(info.EulaVersion);
-        writer.Write(info.UseRatings);
-        writer.Write(sections.DsiRomLength);
-        writer.Write((byte)info.SdShared202Length);
-        writer.Write((byte)info.SdShared203Length);
-        writer.Write((byte)info.SdShared204Length);
-        writer.Write((byte)info.SdShared205Length);
-        writer.Write(info.Arm9iParametersTableOffset);
-        writer.Write(info.Arm7iParametersTableOffset);
-
-        writer.Write(sections.ModcryptArea1Offset);
-        writer.Write(sections.ModcryptArea1Length);
-        writer.Write(sections.ModcryptArea2Offset);
-        writer.Write(sections.ModcryptArea2Length);
-
-        writer.Write(info.TitleId);
-        writer.Write(info.SdPublicSaveLength);
-        writer.Write(info.SdPrivateSaveLength);
-
-        writer.Stream.Position = 0x2F0;
-        writer.Write(info.AgeRatingCero);
-        writer.Write(info.AgeRatingEsrb);
-        writer.Write((byte)0);
-        writer.Write(info.AgeRatingUsk);
-        writer.Write(info.AgeRatingPegiEurope);
-        writer.Write((byte)0);
-        writer.Write(info.AgeRatingPegiPortugal);
-        writer.Write(info.AgeRatingPegiUk);
-        writer.Write(info.AgeRatingAgcb);
-        writer.Write(info.AgeRatingGrb);
-
-        writer.Stream.Position = 0x300;
-        writer.Write(info.Arm9SecureMac.Hash);
-        writer.Write(info.Arm7Mac.Hash);
-        writer.Write(info.DigestMain.Hash);
-        writer.Stream.Position += 0x14; // Banner HMAC read with DS fields
-        writer.Write(info.Arm9iMac.Hash);
-        writer.Write(info.Arm7iMac.Hash);
-        writer.Stream.Position += 0x28; // DS whitelist macs
-        writer.Write(info.Arm9Mac.Hash);
-    }
-
-    private static void WriteGlobalMemoryBankSettings(DataWriter writer, GlobalMemoryBankSettings[] settings)
-    {
-        if (settings is not { Length: 5 * 4 }) {
-            throw new FormatException("Expecting 20 global memory bank settings");
-        }
-
-        for (int i = 0; i < settings.Length; i++) {
-            var setting = settings[i];
-            int maxProcessor = (i == 0) ? 1 : 3;
-            int maxSlot = (i == 0) ? 3 : 7;
-            if ((int)setting.Processor > maxProcessor || setting.OffsetSlot > maxSlot) {
-                throw new ArgumentException($"Invalid global memory bank setting for {i}");
-            }
-
-            int data = (int)setting.Processor;
-            data |= setting.OffsetSlot << 2;
-            data |= (setting.Enabled ? 1 : 0) << 7;
-            writer.Write((byte)data);
-        }
-    }
-
-    private static void WriteLocalMemoryBankSettings(DataWriter writer, LocalMemoryBankSettings[] settings)
-    {
-        if (settings is not { Length: 3 }) {
-            throw new FormatException("Expecting 3 local memory bank settings");
-        }
-
-        uint mbk6 = 0;
-        mbk6 |= (uint)(settings[0].StartAddressSlot << 4);
-        mbk6 |= (uint)(settings[0].ImageSize << 12);
-        mbk6 |= (uint)(settings[0].EndAddressSlot << 20);
-        writer.Write(mbk6);
-
-        for (int i = 0; i < 2; i++) {
-            var setting = settings[i + 1];
-            if (setting.StartAddressSlot > 511 || setting.ImageSize > 3 || setting.EndAddressSlot > 1023) {
-                throw new ArgumentException($"Invalid local memory bank setting for {i}");
-            }
-
-            uint data = (uint)(setting.StartAddressSlot << 3);
-            data |= (uint)(setting.ImageSize << 12);
-            data |= (uint)(setting.EndAddressSlot << 19);
-            writer.Write(data);
-        }
     }
 }

--- a/src/Ekona/Containers/Rom/RomHeader2Binary.cs
+++ b/src/Ekona/Containers/Rom/RomHeader2Binary.cs
@@ -82,8 +82,8 @@ public class RomHeader2Binary :
         writer.Write(info.GlobalMbk9Settings | (info.GlobalWramCntSettings << 24));
 
         writer.Write((uint)source.ProgramInfo.Region);
-        writer.Write(info.AccessControl);
-        writer.Write(info.Arm7ScfgExt7Setting);
+        writer.Write((uint)info.AccessControl);
+        writer.Write((uint)info.ScfgExtendedArm7);
         writer.Stream.Position += 4; // ProgramFeatures written with DS fields
 
         writer.Write(sections.Arm9iOffset);
@@ -129,16 +129,16 @@ public class RomHeader2Binary :
         writer.Write(info.StoragePrivateSaveLength);
 
         writer.Stream.Position = 0x2F0;
-        writer.Write(info.AgeRatingCero);
-        writer.Write(info.AgeRatingEsrb);
+        writer.Write(SerializeAgeRating(info.AgeRatingCero));
+        writer.Write(SerializeAgeRating(info.AgeRatingEsrb));
         writer.Write((byte)0);
-        writer.Write(info.AgeRatingUsk);
-        writer.Write(info.AgeRatingPegiEurope);
+        writer.Write(SerializeAgeRating(info.AgeRatingUsk));
+        writer.Write(SerializeAgeRating(info.AgeRatingPegiEurope));
         writer.Write((byte)0);
-        writer.Write(info.AgeRatingPegiPortugal);
-        writer.Write(info.AgeRatingPegiUk);
-        writer.Write(info.AgeRatingAgcb);
-        writer.Write(info.AgeRatingGrb);
+        writer.Write(SerializeAgeRating(info.AgeRatingPegiPortugal));
+        writer.Write(SerializeAgeRating(info.AgeRatingPegiUk));
+        writer.Write(SerializeAgeRating(info.AgeRatingAgcb));
+        writer.Write(SerializeAgeRating(info.AgeRatingGrb));
 
         writer.Stream.Position = 0x300;
         writer.Write(info.Arm9SecureMac.Hash);
@@ -195,6 +195,14 @@ public class RomHeader2Binary :
             data |= (uint)(setting.EndAddressSlot << 19);
             writer.Write(data);
         }
+    }
+
+    private static byte SerializeAgeRating(AgeRating rating)
+    {
+        byte value = (byte)(rating.Age & 0x1F);
+        value |= (byte)((rating.Prohibited ? 1 : 0) << 6);
+        value |= (byte)((rating.Enabled ? 1 : 0) << 7);
+        return value;
     }
 
     private void WriteDsFields(DataWriter writer, RomHeader source)

--- a/src/Ekona/Containers/Rom/RomSectionInfo.cs
+++ b/src/Ekona/Containers/Rom/RomSectionInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright(c) 2021 SceneGate
+// Copyright(c) 2021 SceneGate
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -98,5 +98,105 @@ namespace SceneGate.Ekona.Containers.Rom
         /// Gets or sets the size of the header.
         /// </summary>
         public uint HeaderSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets the offset for the ARM-9 program for DSi devices.
+        /// </summary>
+        public uint Arm9iOffset { get; set; }
+
+        /// <summary>
+        /// Gets or sets the size of the ARM-9 program for DSi devices.
+        /// </summary>
+        public uint Arm9iSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets the offset for the ARM-7 program for DSi devices.
+        /// </summary>
+        public uint Arm7iOffset { get; set; }
+
+        /// <summary>
+        /// Gets or sets the size of the ARM-7 program for DSi devices.
+        /// </summary>
+        public uint Arm7iSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets the offset for the data to digest (hash) of the DS ROM section.
+        /// </summary>
+        public uint DigestNitroOffset { get; set; }
+
+        /// <summary>
+        /// Gets or sets the length for the data to digest (hash) for the DS ROM section.
+        /// </summary>
+        public uint DigestNitroLength { get; set; }
+
+        /// <summary>
+        /// Gets or sets the offset for the data to digest (hash) of the DSi ROM section.
+        /// </summary>
+        public uint DigestTwilightOffset { get; set; }
+
+        /// <summary>
+        /// Gets or sets the offset for the data to digest (hash) of the DSi ROM section.
+        /// </summary>
+        public uint DigestTwilightLength { get; set; }
+
+        /// <summary>
+        /// Gets or sets the offset for the digest hash table of sectors.
+        /// </summary>
+        public uint DigestSectorHashtableOffset { get; set; }
+
+        /// <summary>
+        /// Gets or sets the length of the digest hash table of sectors.
+        /// </summary>
+        public uint DigestSectorHashtableLength { get; set; }
+
+        /// <summary>
+        /// Gets or sets the offset for the digest hash table of blocks (hashes of sectors).
+        /// </summary>
+        public uint DigestBlockHashtableOffset { get; set; }
+
+        /// <summary>
+        /// Gets or sets the length of the digest hash table of blocks (hashes of sectors).
+        /// </summary>
+        public uint DigestBlockHashtableLength { get; set; }
+
+        /// <summary>
+        /// Gets or sets the size for each sector digest.
+        /// </summary>
+        public uint DigestSectorSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of sectors to hash per block.
+        /// </summary>
+        public uint DigestBlockSectorCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the banner length.
+        /// </summary>
+        public uint BannerLength { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ROM size including the DSi section.
+        /// </summary>
+        public uint DsiRomLength { get; set; }
+
+        /// <summary>
+        /// Gets or sets the offset for the first area modcrypted in the ROM.
+        /// </summary>
+        public uint ModcryptArea1Offset { get; set; }
+
+        /// <summary>
+        /// Gets or sets the length for the first area modcrypted in the ROM.
+        /// </summary>
+        public uint ModcryptArea1Length { get; set; }
+
+        /// <summary>
+        /// Gets or sets the offset for the second area modcrypted in the ROM.
+        /// </summary>
+        public uint ModcryptArea2Offset { get; set; }
+
+        /// <summary>
+        /// Gets or sets the length for the second area modcrypted in the ROM.
+        /// </summary>
+        public uint ModcryptArea2Length { get; set; }
     }
 }

--- a/src/Ekona/Containers/Rom/ScfgExtendedFeaturesArm7.cs
+++ b/src/Ekona/Containers/Rom/ScfgExtendedFeaturesArm7.cs
@@ -1,0 +1,66 @@
+// Copyright (c) 2022 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace SceneGate.Ekona.Containers.Rom;
+
+/// <summary>
+/// Define the control register (SCFG) extended features for DSi ARM7.
+/// </summary>
+[Flags]
+[SuppressMessage("", "S4070", Justification = "False positive")]
+public enum ScfgExtendedFeaturesArm7
+{
+    /// <summary>
+    /// No setting set.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Use the revised ARM7 DMA circuit instead of the nitro (DS) one.
+    /// </summary>
+    RevisedArm7DmaCircuit = 1 << 0,
+
+    /// <summary>
+    /// Use the revised sound DMA instead of the nitro (DS) one.
+    /// </summary>
+    RevisedSoundDma = 1 << 1,
+
+    /// <summary>
+    /// Use the revised sound instead of the nitro (DS) one.
+    /// </summary>
+    RevisedSound = 1 << 2,
+
+    /// <summary>
+    /// Use the extended sound DMA instead of the nitro (DS) one.
+    /// </summary>
+    ExtendedSoundDma = 1 << 10,
+
+    /// <summary>
+    /// Allow access to the SD/eMMC registers.
+    /// </summary>
+    AccessStorageRegisters = 1 << 18,
+
+    /// <summary>
+    /// Allow access to the SCFG/MBK registers.
+    /// </summary>
+    AccessScfgMbkRegisters = 1 << 31,
+}

--- a/src/Ekona/Containers/Rom/TwilightAccessControl.cs
+++ b/src/Ekona/Containers/Rom/TwilightAccessControl.cs
@@ -1,0 +1,126 @@
+// Copyright (c) 2022 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace SceneGate.Ekona.Containers.Rom;
+
+/// <summary>
+/// Access control of DSi (Twilight) software.
+/// </summary>
+[Flags]
+[SuppressMessage("", "S4070", Justification = "False positive")]
+public enum TwilightAccessControl
+{
+    /// <summary>
+    /// No access control set.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Use "common key" -> 0x3080F000 = 0x03FFC600 + 0x00.
+    /// </summary>
+    CommonClientKey = 1 << 0,
+
+    /// <summary>
+    /// Use AES slot B -> 0x0380F010 = 0x03FFC400 + 0x180 and KEY1 unchanged.
+    /// </summary>
+    AesSlotB = 1 << 1,
+
+    /// <summary>
+    /// Use AES slot C -> 0x0380F020 = 0x03FFC400 + 0x190 and KEY2.Y = 0x03FFC400 + 0x1A0.
+    /// </summary>
+    AesSlotC = 1 << 2,
+
+    /// <summary>
+    /// Allow access to SD Card device (I).
+    /// </summary>
+    SdCard = 1 << 3,
+
+    /// <summary>
+    /// Allow access to NAND (device A-H and KEY3 intact).
+    /// </summary>
+    NandAccess = 1 << 4,
+
+    /// <summary>
+    /// Game card power on.
+    /// </summary>
+    GameCardPowerOn = 1 << 5,
+
+    /// <summary>
+    /// Software uses shared2 file from storage SD/eMMC.
+    /// </summary>
+    Shared2File = 1 << 6,
+
+    /// <summary>
+    /// Sign the camera photo JPEG files for launcher (AES slot B).
+    /// </summary>
+    SignJpegForLauncher = 1 << 7,
+
+    /// <summary>
+    /// Game card nitro mode.
+    /// </summary>
+    GameCardNitroMode = 1 << 8,
+
+    /// <summary>
+    /// SSL client certificates (AES slot A) -> KEY0 = 0x03FFC600 + 0x30.
+    /// </summary>
+    SslClientCert = 1 << 9,
+
+    /// <summary>
+    /// Sign the camera photo JPEG files for the user (AES slot B).
+    /// </summary>
+    SignJpegForUser = 1 << 10,
+
+    /// <summary>
+    /// Allow read access for photos.
+    /// </summary>
+    PhotoReadAccess = 1 << 11,
+
+    /// <summary>
+    /// Allow write access for photos.
+    /// </summary>
+    PhotoWriteAccess = 1 << 12,
+
+    /// <summary>
+    /// Allow read access to the SD card.
+    /// </summary>
+    SdCardReadAccess = 1 << 13,
+
+    /// <summary>
+    /// Allow write access to the SD card.
+    /// </summary>
+    SdCardWriteAccess = 1 << 14,
+
+    /// <summary>
+    /// Read access to cartridge save files.
+    /// </summary>
+    GameCardSaveReadAccess = 1 << 15,
+
+    /// <summary>
+    /// Write access to cartridge save files.
+    /// </summary>
+    GameCardSaveWriteAccess = 1 << 16,
+
+    /// <summary>
+    /// Debugger common client key -> 0x0380F000 = 0x03FFC600 + 0x10.
+    /// </summary>
+    DebuggerCommonClientKey = 1 << 31,
+}

--- a/src/Ekona/Security/IOExtensions.cs
+++ b/src/Ekona/Security/IOExtensions.cs
@@ -45,7 +45,7 @@ internal static class IOExtensions
     /// </summary>
     /// <param name="reader">The data reader with the stream to read the HMAC.</param>
     /// <returns>The information about the HMAC verification.</returns>
-    public static HashInfo ReadHMACSHA1(this DataReader reader)
+    public static HashInfo ReadHmacSha1(this DataReader reader)
     {
         byte[] hmac = reader.ReadBytes(0x14);
         return new HashInfo("HMAC-SHA1", hmac);
@@ -56,7 +56,7 @@ internal static class IOExtensions
     /// </summary>
     /// <param name="reader">The data reader with the stream to read the signature.</param>
     /// <returns>The information about the signature.</returns>
-    public static HashInfo ReadSignatureSHA1RSA(this DataReader reader)
+    public static HashInfo ReadSignatureSha1Rsa(this DataReader reader)
     {
         byte[] signature = reader.ReadBytes(128);
         return new HashInfo("RawRSA-SHA1", signature);


### PR DESCRIPTION
### Description

- Read (deserialize) and write (serialize) new DSi header fields
- Fix unit code enumeration values
- Improve region support
- Verify and regenerate new HMAC available in DSi programs.
- Update cake to 2.2 and latest minor version of .NET 6 SDK

### Example

Use the same classes to read ROMs as for DS. It will dynamically detect if it's a DSi enhanced or Dsi exclusive program and then read the new fields.

This closes #9 