### PR TITLE
:sparkles: Read and write ARMi programs and generate twilight ROM area

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,9 +19,12 @@
         "Ekona",
         "ESRB",
         "HMAC",
+        "Itcm",
         "NAND",
         "Pegi",
         "SCFG",
+        "Texim",
+        "Unswizzle",
         "WRAM"
     ],
 }

--- a/README.md
+++ b/README.md
@@ -20,12 +20,13 @@ The library supports .NET 6.0 and above on Linux, Window and MacOS.
   - HMAC validation and re-generation when keys are provided.
   - Signature validation when keys are provided.
 - DSi cartridge:
+  - Filesystem: read and write `arm9i` and `arm7i` programs.
   - Header: read and write
   - Animated banner icons
   - HMAC validation and re-generation when keys are provided.
   - Signature validation when keys are provided.
-  - _arm9i, arm7i and digest generation not supported yet._
-  - _Modcrypt encryption and decryption not supported yet._
+  - _Digest hashtable generation not supported yet #12._
+  - _Modcrypt encryption and decryption not supported yet #11._
 
 ## Documentation
 

--- a/src/Ekona.Tests/Containers/Rom/Binary2NitroRomTests.cs
+++ b/src/Ekona.Tests/Containers/Rom/Binary2NitroRomTests.cs
@@ -21,7 +21,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using FluentAssertions;
-using Microsoft.VisualStudio.TestPlatform.TestHost;
 using NUnit.Framework;
 using SceneGate.Ekona.Containers.Rom;
 using SceneGate.Ekona.Security;

--- a/src/Ekona/Containers/Rom/Binary2Banner.cs
+++ b/src/Ekona/Containers/Rom/Binary2Banner.cs
@@ -48,7 +48,7 @@ namespace SceneGate.Ekona.Containers.Rom
         private const int IconHeight = 32;
 
         /// <summary>
-        /// Gets the maxmimum number of animated images.
+        /// Gets the maximum number of animated images.
         /// </summary>
         public static int NumAnimatedImages => 8;
 

--- a/src/Ekona/Containers/Rom/Binary2NitroRom.cs
+++ b/src/Ekona/Containers/Rom/Binary2NitroRom.cs
@@ -73,7 +73,6 @@ namespace SceneGate.Ekona.Containers.Rom
             ReadBanner();
             ReadFat();
             ReadPrograms();
-            // TODO: Decrypt programs with modcrypt #11
             ReadProgramCodeParameters();
             ReadFileSystem();
             ValidateSignatures();
@@ -134,6 +133,7 @@ namespace SceneGate.Ekona.Containers.Rom
 
         private void ReadPrograms()
         {
+            // TODO: Decrypt programs with modcrypt #11
             var arm9 = new BinaryFormat(reader.Stream, header.SectionInfo.Arm9Offset, header.SectionInfo.Arm9Size);
             rom.System.Children["arm9"].ChangeFormat(arm9);
             ReadOverlayTable(

--- a/src/Ekona/Containers/Rom/Binary2NitroRom.cs
+++ b/src/Ekona/Containers/Rom/Binary2NitroRom.cs
@@ -73,6 +73,7 @@ namespace SceneGate.Ekona.Containers.Rom
             ReadBanner();
             ReadFat();
             ReadPrograms();
+            // TODO: Decrypt programs with modcrypt #11
             ReadProgramCodeParameters();
             ReadFileSystem();
             ValidateSignatures();
@@ -146,6 +147,14 @@ namespace SceneGate.Ekona.Containers.Rom
                 header.ProgramInfo.Overlays7Info,
                 header.SectionInfo.Overlay7TableOffset,
                 header.SectionInfo.Overlay7TableSize);
+
+            if (header.ProgramInfo.UnitCode != DeviceUnitKind.DS) {
+                var arm9i = new BinaryFormat(reader.Stream, header.SectionInfo.Arm9iOffset, header.SectionInfo.Arm9iSize);
+                rom.System.Add(new Node("arm9i", arm9i));
+
+                var arm7i = new BinaryFormat(reader.Stream, header.SectionInfo.Arm7iOffset, header.SectionInfo.Arm7iSize);
+                rom.System.Add(new Node("arm7i", arm7i));
+            }
         }
 
         private void ReadProgramCodeParameters()
@@ -314,6 +323,8 @@ namespace SceneGate.Ekona.Containers.Rom
                 byte[] arm9Hash = hashGenerator.GenerateArm9NoSecureAreaHmac(reader.Stream, header.SectionInfo);
                 programInfo.DsiInfo.Arm9Mac.Validate(arm9Hash);
             }
+
+            // TODO: Verify digest hashes #12
         }
 
         private struct FileAddress

--- a/src/Ekona/Containers/Rom/Binary2RomHeader.cs
+++ b/src/Ekona/Containers/Rom/Binary2RomHeader.cs
@@ -31,6 +31,7 @@ namespace SceneGate.Ekona.Containers.Rom
         IInitializer<DsiKeyStore>,
         IConverter<IBinary, RomHeader>
     {
+        private const int SecureAreaLength = 16 * 1024;
         private DsiKeyStore keyStore;
 
         /// <summary>
@@ -152,10 +153,17 @@ namespace SceneGate.Ekona.Containers.Rom
             // Pos: 0x220
             sections.ModcryptArea1Offset = reader.ReadUInt32();
             sections.ModcryptArea1Length = reader.ReadUInt32();
-            info.ModcryptArea1Target = GetModcryptTarget(sections.ModcryptArea1Offset, sections);
+            info.ModcryptArea1Target = GetModcryptTarget(
+                sections.ModcryptArea1Offset,
+                sections.ModcryptArea1Length,
+                sections);
+
             sections.ModcryptArea2Offset = reader.ReadUInt32();
             sections.ModcryptArea2Length = reader.ReadUInt32();
-            info.ModcryptArea2Target = GetModcryptTarget(sections.ModcryptArea2Offset, sections);
+            info.ModcryptArea2Target = GetModcryptTarget(
+                sections.ModcryptArea2Offset,
+                sections.ModcryptArea2Length,
+                sections);
 
             // Pos: 0x230
             info.TitleId = reader.ReadUInt64();
@@ -227,7 +235,7 @@ namespace SceneGate.Ekona.Containers.Rom
             return settings;
         }
 
-        private static ModcryptTargetKind GetModcryptTarget(uint offset, RomSectionInfo info)
+        private static ModcryptTargetKind GetModcryptTarget(uint offset, uint length, RomSectionInfo info)
         {
             if (offset == 0)
                 return ModcryptTargetKind.None;
@@ -235,6 +243,8 @@ namespace SceneGate.Ekona.Containers.Rom
                 return ModcryptTargetKind.Arm9;
             if (offset == info.Arm7Offset)
                 return ModcryptTargetKind.Arm7;
+            if (offset == info.Arm9iOffset && length == SecureAreaLength)
+                return ModcryptTargetKind.Arm9iSecureArea;
             if (offset == info.Arm9iOffset)
                 return ModcryptTargetKind.Arm9i;
             if (offset == info.Arm7iOffset)

--- a/src/Ekona/Containers/Rom/ModcryptTargetKind.cs
+++ b/src/Ekona/Containers/Rom/ModcryptTargetKind.cs
@@ -45,6 +45,11 @@ public enum ModcryptTargetKind
     Arm9i,
 
     /// <summary>
+    /// ARM9i (DSi) secure area program only.
+    /// </summary>
+    Arm9iSecureArea,
+
+    /// <summary>
     /// ARM7i (DSi) program.
     /// </summary>
     Arm7i,

--- a/src/Ekona/Containers/Rom/NitroRom2Binary.cs
+++ b/src/Ekona/Containers/Rom/NitroRom2Binary.cs
@@ -39,7 +39,8 @@ public class NitroRom2Binary :
     IConverter<NodeContainerFormat, BinaryFormat>
 {
     private const int PaddingSize = 0x200;
-    private const long SecureAreaLength = 16 * 1024;
+    private const int TwilightPaddingSize = 0x400;
+    private const int SecureAreaLength = 16 * 1024;
     private readonly SortedList<int, NodeInfo> nodesById = new SortedList<int, NodeInfo>();
     private readonly SortedList<int, NodeInfo> nodesByOffset = new SortedList<int, NodeInfo>();
     private Stream? initializedOutputStream;
@@ -78,12 +79,20 @@ public class NitroRom2Binary :
 
         // Binary order is:
         // - Header
+        // - Unknown
         // - ARM9: program, table, overlays
         // - ARM7: program, table, overlays
         // - FNT: main tables, entry tables
         // - FAT: including overlays
         // - Banner
         // - Files
+        // - (DSi) Digest sector
+        // - (DSi) Digest block
+        // - Padding to round up to 16 MB (XX000000).
+        // ---- Twilight ROM content ----
+        // - Unknown, probably padding but due to cartridge protocol 3x 0x8000..0x9000
+        // - ARM9i
+        // - ARM7i
         var binary = new BinaryFormat(initializedOutputStream ?? new DataStream());
         binary.Stream.Position = 0;
         writer = new DataWriter(binary.Stream);
@@ -99,6 +108,7 @@ public class NitroRom2Binary :
         // Sort nodes by ID
         PopulateNodeInfo();
 
+        // TODO: Encrypt arm9/arm7/arm9i/arm7i #11
         WritePrograms();
 
         WriteFileSystem();
@@ -119,10 +129,31 @@ public class NitroRom2Binary :
 
         WriteBanner();
 
+        if (programInfo.UnitCode != DeviceUnitKind.DS) {
+            // TODO: Generate actual digest #12
+            WriteEmptyDigest();
+        }
+
+        sectionInfo.RomSize = (uint)writer.Stream.Length;
+
+        if (programInfo.UnitCode != DeviceUnitKind.DS) {
+            // Padding to start twilight section
+            writer.WritePadding(0xFF, 0x100000);
+
+            WriteTwilightPrograms();
+            sectionInfo.DigestTwilightOffset = sectionInfo.Arm9iOffset;
+
+            sectionInfo.DsiRomLength = (uint)writer.Stream.Length;
+
+            var modcrypt1 = FakeModcryptEncrypt(programInfo.DsiInfo.ModcryptArea1Target);
+            var modcrypt2 = FakeModcryptEncrypt(programInfo.DsiInfo.ModcryptArea2Target);
+            (sectionInfo.ModcryptArea1Offset, sectionInfo.ModcryptArea1Length) = modcrypt1;
+            (sectionInfo.ModcryptArea2Offset, sectionInfo.ModcryptArea2Length) = modcrypt2;
+        }
+
         WriteHeader();
 
         // Fill size to the cartridge size
-        sectionInfo.RomSize = (uint)writer.Stream.Length;
         writer.WriteUntilLength(0xFF, programInfo.CartridgeSize);
 
         return binary;
@@ -156,13 +187,11 @@ public class NitroRom2Binary :
             header.CopyrightLogo = new byte[156];
         }
 
-        sectionInfo.RomSize = (uint)writer.Stream.Length;
-
         GenerateSignatures();
 
         // We don't calculate the header length but we expect it's preset.
         // It's used inside the converter to pad.
-        var binaryHeader = (BinaryFormat)ConvertFormat.With<RomHeader2Binary>(header);
+        var binaryHeader = (IBinary)ConvertFormat.With<RomHeader2Binary>(header);
         writer.Stream.Position = 0;
         binaryHeader.Stream.WriteTo(writer.Stream);
     }
@@ -216,7 +245,7 @@ public class NitroRom2Binary :
             byte[] digestHash = hashGenerator.GenerateDigestBlockHmac(writer.Stream, sectionInfo);
             programInfo.DsiInfo.DigestMain.ChangeHash(digestHash);
 
-            // TODO: After modcrypt implementation HMAC for ARM9i and ARM7i.
+            // TODO: After modcrypt implementation HMAC for ARM9i and ARM7i #11
             byte[] arm9Hash = hashGenerator.GenerateArm9NoSecureAreaHmac(writer.Stream, sectionInfo);
             programInfo.DsiInfo.Arm9Mac.ChangeHash(arm9Hash);
         }
@@ -237,6 +266,9 @@ public class NitroRom2Binary :
         GetChildSafe("system/banner")
             .TransformWith<Banner2Binary>()
             .Stream!.WriteTo(writer.Stream);
+
+        writer.Stream.Position = sectionInfo.BannerOffset;
+        sectionInfo.BannerLength = (uint)Binary2Banner.GetSize(writer.Stream);
     }
 
     private void WritePrograms()
@@ -249,11 +281,39 @@ public class NitroRom2Binary :
         WriteOverlays(false);
     }
 
+    private void WriteTwilightPrograms()
+    {
+        // First 0x3000 bytes
+        // Unknown but let's replicate what the dumper gets
+        byte[] unknownTwilightData = new byte[0x1000];
+        writer.Stream.Position = 0x8000;
+        writer.Stream.Read(unknownTwilightData);
+
+        writer.Stream.Seek(0, SeekOrigin.End);
+        writer.Write(unknownTwilightData);
+        writer.Write(unknownTwilightData);
+        writer.Write(unknownTwilightData);
+
+        // ARM9i
+        IBinary arm9i = GetChildFormatSafe<IBinary>("system/arm9i");
+        sectionInfo.Arm9iSize = (uint)arm9i.Stream.Length;
+        sectionInfo.Arm9iOffset = (uint)writer.Stream.Length;
+        arm9i.Stream.WriteTo(writer.Stream);
+        writer.WritePadding(0xFF, TwilightPaddingSize);
+
+        // ARM7i
+        IBinary arm7i = GetChildFormatSafe<IBinary>("system/arm7i");
+        sectionInfo.Arm7iSize = (uint)arm7i.Stream.Length;
+        sectionInfo.Arm7iOffset = (uint)writer.Stream.Length;
+        arm7i.Stream.WriteTo(writer.Stream);
+        writer.WritePadding(0xFF, TwilightPaddingSize);
+    }
+
     private void WriteProgram(bool isArm9)
     {
         string armPath = isArm9 ? "system/arm9" : "system/arm7";
 
-        BinaryFormat binaryArm = GetChildFormatSafe<BinaryFormat>(armPath);
+        IBinary binaryArm = GetChildFormatSafe<IBinary>(armPath);
         uint armLength = (uint)binaryArm.Stream.Length;
         uint armOffset = armLength > 0 ? (uint)writer.Stream.Position : 0;
         binaryArm.Stream.WriteTo(writer.Stream);
@@ -354,7 +414,7 @@ public class NitroRom2Binary :
             writer.Write(info.StaticInitStart);
             writer.Write(info.StaticInitEnd);
             writer.Write(info.OverlayId);
-            uint encodingInfo = info.CompressedSize;
+            uint encodingInfo = info.IsCompressed ? info.CompressedSize : 0;
             encodingInfo |= (uint)((info.IsCompressed ? 1 : 0) << 24);
             encodingInfo |= (uint)((info.IsSigned ? 1 : 0) << 25);
             writer.Write(encodingInfo);
@@ -515,6 +575,54 @@ public class NitroRom2Binary :
                 nodesByOffset.Add(info.PhysicalId, info);
             }
         }
+    }
+
+    private void WriteEmptyDigest()
+    {
+        uint sha1HashLength = 0x14;
+        sectionInfo.DigestBlockSectorCount = 0x20;
+        sectionInfo.DigestSectorSize = 0x400;
+
+        // Digest needs padding to its sector size, so pad ROM content to it.
+        writer.Stream.Seek(0, SeekOrigin.End);
+        writer.WritePadding(0xFF, (int)sectionInfo.DigestSectorSize);
+
+        sectionInfo.DigestNitroOffset = sectionInfo.Arm9Offset;
+        sectionInfo.DigestNitroLength = (uint)(writer.Stream.Length - sectionInfo.DigestNitroOffset);
+
+        // Twilight digest offset will be set later, once we know this size.
+        uint arm9iLength = (uint)GetChildFormatSafe<IBinary>("system/arm9i").Stream.Length.Pad(TwilightPaddingSize);
+        uint arm7iLength = (uint)GetChildFormatSafe<IBinary>("system/arm7i").Stream.Length.Pad(TwilightPaddingSize);
+        sectionInfo.DigestTwilightLength = arm9iLength + arm7iLength;
+
+        uint numSectorHashes = (sectionInfo.DigestNitroLength + sectionInfo.DigestTwilightLength) / sectionInfo.DigestSectorSize;
+        uint sectorHashLength = numSectorHashes * sha1HashLength;
+
+        uint numBlockHashes = numSectorHashes.Pad((int)sectionInfo.DigestBlockSectorCount) / sectionInfo.DigestBlockSectorCount;
+        uint blockHashLength = numBlockHashes * sha1HashLength;
+
+        sectionInfo.DigestSectorHashtableOffset = (uint)writer.Stream.Length;
+        sectionInfo.DigestSectorHashtableLength = sectorHashLength.Pad(PaddingSize);
+        writer.WriteTimes(0xCA, sectorHashLength);
+        writer.WritePadding(0, PaddingSize);
+
+        sectionInfo.DigestBlockHashtableOffset = (uint)writer.Stream.Length;
+        sectionInfo.DigestBlockHashtableLength = blockHashLength;
+        writer.WriteTimes(0xFE, blockHashLength);
+        writer.WritePadding(0xFF, PaddingSize);
+    }
+
+    private (uint, uint) FakeModcryptEncrypt(ModcryptTargetKind target)
+    {
+        return target switch {
+            ModcryptTargetKind.None => (0, 0),
+            ModcryptTargetKind.Arm9 => (sectionInfo.Arm9Offset, sectionInfo.Arm9Size),
+            ModcryptTargetKind.Arm7 => (sectionInfo.Arm7Offset, sectionInfo.Arm7Size),
+            ModcryptTargetKind.Arm9i => (sectionInfo.Arm9iOffset, sectionInfo.Arm9iSize),
+            ModcryptTargetKind.Arm9iSecureArea => (sectionInfo.Arm9iOffset, SecureAreaLength),
+            ModcryptTargetKind.Arm7i => (sectionInfo.Arm7iOffset, sectionInfo.Arm7iSize),
+            _ => throw new NotSupportedException($"Unsupported modcrypt area: {target}"),
+        };
     }
 
     private struct NodeInfo

--- a/src/Ekona/Containers/Rom/NitroRom2Binary.cs
+++ b/src/Ekona/Containers/Rom/NitroRom2Binary.cs
@@ -108,7 +108,6 @@ public class NitroRom2Binary :
         // Sort nodes by ID
         PopulateNodeInfo();
 
-        // TODO: Encrypt arm9/arm7/arm9i/arm7i #11
         WritePrograms();
 
         WriteFileSystem();
@@ -145,6 +144,7 @@ public class NitroRom2Binary :
 
             sectionInfo.DsiRomLength = (uint)writer.Stream.Length;
 
+            // TODO: Encrypt arm9/arm7/arm9i/arm7i #11
             var modcrypt1 = FakeModcryptEncrypt(programInfo.DsiInfo.ModcryptArea1Target);
             var modcrypt2 = FakeModcryptEncrypt(programInfo.DsiInfo.ModcryptArea2Target);
             (sectionInfo.ModcryptArea1Offset, sectionInfo.ModcryptArea1Length) = modcrypt1;


### PR DESCRIPTION
### Description

DSi ROMs are identical except for the digest hashtable.

- Read and write `arm9i` and `arm7i`.
- Fix overlay compression size when it's not compressed
- Write empty digest hashtable

### Example

Use the `Binary2NitroRom` and `NitroRom2Binary` converters. Access to the new nodes at `system/arm9i` and `system/arm7i`.

This closes #10