### PR TITLE
:bug: :racehorse: Fix ROM generation on specific stream and improve performance

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,7 @@
     "cSpell.words": [
         "Agcb",
         "cref",
+        "Diagnoser",
         "Ekona",
         "ESRB",
         "HMAC",

--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ To just build and test quickly, run:
 dotnet cake --target=BuildTest
 ```
 
+To run the performance test with memory and CPU traces:
+
+```sh
+dotnet run --project src/Ekona.PerformanceTests/ -c Release -- -f "*<TestName>*" -m -p EP --maxWidth 60
+```
+
 ## References
 
 - [GBATek](https://problemkaputt.de/gbatek.htm)

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,14 +1,14 @@
 <Project>
     <!-- Centralize dependency management -->
     <ItemGroup>
-        <PackageVersion Include="Yarhl" Version="4.0.0-preview.153" />
+        <PackageVersion Include="Yarhl" Version="4.0.0-preview.157" />
         <PackageVersion Include="Texim" Version="0.1.0-preview.129" />
         <PackageVersion Include="System.Data.HashFunction.CRC" Version="2.0.0" />
         <PackageVersion Include="Portable.BouncyCastle" Version="1.9.0" />
 
         <PackageVersion Include="YamlDotNet" Version="11.2.1" />
-        <PackageVersion Include="FluentAssertions" Version="6.5.1" />
-        <PackageVersion Include="nunit" Version="3.13.2" />
+        <PackageVersion Include="FluentAssertions" Version="6.6.0" />
+        <PackageVersion Include="nunit" Version="3.13.3" />
         <PackageVersion Include="NUnit3TestAdapter" Version="4.2.1" />
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.1.0"/>
         <PackageVersion Include="coverlet.collector" Version="3.1.2" />
@@ -17,7 +17,7 @@
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
 
         <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
-        <PackageVersion Include="SonarAnalyzer.CSharp" Version="8.36.1.44192" />
-        <PackageVersion Include="Roslynator.Analyzers" Version="4.0.2" />
+        <PackageVersion Include="SonarAnalyzer.CSharp" Version="8.37.0.45539" />
+        <PackageVersion Include="Roslynator.Analyzers" Version="4.1.0" />
     </ItemGroup>
 </Project>

--- a/src/Ekona.PerformanceTests/Binary2NitroRomTest.cs
+++ b/src/Ekona.PerformanceTests/Binary2NitroRomTest.cs
@@ -1,0 +1,81 @@
+// Copyright (c) 2022 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using BenchmarkDotNet.Attributes;
+using SceneGate.Ekona.Containers.Rom;
+using SceneGate.Ekona.Security;
+using Yarhl.FileFormat;
+using Yarhl.IO;
+
+namespace SceneGate.Ekona.PerformanceTests;
+
+public class Binary2NitroRomTest
+{
+    private BinaryFormat binaryRom = null!;
+    private DsiKeyStore keyStore = null!;
+    private NitroRom root = null!;
+    private DataStream outputStream = null!;
+
+    public static IEnumerable<FilePathInfo> RomPaths => ResourceManager.GetRoms();
+
+    [ParamsAllValues]
+    public bool UseKeys { get; set; }
+
+    [ParamsSource(nameof(RomPaths))]
+    public FilePathInfo RomPath { get; set; } = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        keyStore = ResourceManager.GetDsiKeyStore();
+        binaryRom = new BinaryFormat(DataStreamFactory.FromFile(RomPath.Path, FileOpenMode.Read));
+        root = (NitroRom)ConvertFormat.With<Binary2NitroRom>(binaryRom);
+        outputStream = new DataStream();
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        root?.Dispose();
+        binaryRom?.Dispose();
+        outputStream?.Dispose();
+    }
+
+    [Benchmark]
+    public NitroRom ReadRom()
+    {
+        var converter = new Binary2NitroRom();
+        if (UseKeys) {
+            converter.Initialize(keyStore);
+        }
+
+        return converter.Convert(binaryRom);
+    }
+
+    [Benchmark]
+    public void WriteRom()
+    {
+        var converter = new NitroRom2Binary();
+
+        DsiKeyStore? runKeys = UseKeys ? keyStore : null;
+        converter.Initialize(new NitroRom2BinaryParams { KeyStore = runKeys, OutputStream = outputStream });
+
+        converter.Convert(root);
+    }
+}

--- a/src/Ekona.PerformanceTests/Ekona.PerformanceTests.csproj
+++ b/src/Ekona.PerformanceTests/Ekona.PerformanceTests.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Ekona\Ekona.csproj" />
     <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="YamlDotNet" />
   </ItemGroup>
 
 </Project>

--- a/src/Ekona.PerformanceTests/FilePathInfo.cs
+++ b/src/Ekona.PerformanceTests/FilePathInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 SceneGate
+// Copyright (c) 2022 SceneGate
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -17,12 +17,13 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-using BenchmarkDotNet.Running;
-
 namespace SceneGate.Ekona.PerformanceTests;
 
-public static class Program
+public class FilePathInfo
 {
-    public static void Main(string[] args) =>
-        BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+    public FilePathInfo(string path) => Path = path ?? throw new ArgumentNullException(nameof(path));
+
+    public string Path { get; set; }
+
+    public override string ToString() => System.IO.Path.GetFileName(Path);
 }

--- a/src/Ekona.PerformanceTests/ResourceManager.cs
+++ b/src/Ekona.PerformanceTests/ResourceManager.cs
@@ -1,0 +1,65 @@
+// Copyright (c) 2022 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using SceneGate.Ekona.Security;
+using YamlDotNet.Serialization;
+
+namespace SceneGate.Ekona.PerformanceTests;
+
+public static class ResourceManager
+{
+    public static string ResourceDirectory {
+        get {
+            string? envVar = Environment.GetEnvironmentVariable("SCENEGATE_TEST_DIR");
+            if (string.IsNullOrEmpty(envVar)) {
+                throw new InvalidOperationException("Missing environment variable");
+            }
+
+            return envVar;
+        }
+    }
+
+    public static DsiKeyStore GetDsiKeyStore()
+    {
+        string keysPath = Path.Combine(ResourceDirectory, "dsi_keys.yml");
+        if (!File.Exists(keysPath)) {
+            throw new InvalidOperationException("Missing keys file");
+        }
+
+        string keysYaml = File.ReadAllText(keysPath);
+        return new DeserializerBuilder()
+            .Build()
+            .Deserialize<DsiKeyStore>(keysYaml);
+    }
+
+    public static IEnumerable<FilePathInfo> GetRoms()
+    {
+        string containerDir = Path.Combine(ResourceDirectory, "Containers");
+        string filePath = Path.Combine(containerDir, "rom.txt");
+        if (!File.Exists(filePath)) {
+            return Array.Empty<FilePathInfo>();
+        }
+
+        return File.ReadAllLines(filePath)
+            .Select(line => line.Trim())
+            .Where(line => !string.IsNullOrWhiteSpace(line) && !line.StartsWith('#'))
+            .Select(l => Path.Combine(containerDir, l.Split(",")[1]))
+            .Select(p => new FilePathInfo(p));
+    }
+}

--- a/src/Ekona.Tests/Containers/Rom/Binary2NitroRomTests.cs
+++ b/src/Ekona.Tests/Containers/Rom/Binary2NitroRomTests.cs
@@ -256,7 +256,6 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
             ownStream.Compare(createdStream.Stream).Should().BeTrue();
         }
 
-
         [TestCaseSource(nameof(GetFiles))]
         public void ReadWriteThreeWaysRomWithKeyGeneratesSameHashes(string infoPath, string romPath)
         {

--- a/src/Ekona.Tests/Containers/Rom/Binary2NitroRomTests.cs
+++ b/src/Ekona.Tests/Containers/Rom/Binary2NitroRomTests.cs
@@ -246,11 +246,13 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
             var returnStream = (BinaryFormat)ConvertFormat.With<NitroRom2Binary, NitroRom2BinaryParams>(converterParams, rom);
 
             returnStream.Stream.Should().BeSameAs(ownStream);
+            ownStream.Length.Should().Be(createdStream.Stream.Length);
             ownStream.Compare(createdStream.Stream).Should().BeTrue();
 
             // Second pass
             ConvertFormat.With<NitroRom2Binary, NitroRom2BinaryParams>(converterParams, rom);
             ownStream.Disposed.Should().BeFalse();
+            ownStream.Length.Should().Be(createdStream.Stream.Length);
             ownStream.Compare(createdStream.Stream).Should().BeTrue();
         }
 

--- a/src/Ekona/Containers/Rom/NitroRom2Binary.cs
+++ b/src/Ekona/Containers/Rom/NitroRom2Binary.cs
@@ -93,11 +93,9 @@ public class NitroRom2Binary :
         // - ARM7i
         root = source.Root;
 
-        var binary = new BinaryFormat(initializedOutputStream ?? new DataStream());
-
-        // Create a wrapper so the length starts from 0. We shouldn't dispose it.
-        var writeStream = new DataStream(binary.Stream);
-        writer = new DataWriter(writeStream);
+        Stream outputStream = initializedOutputStream ?? new DataStream();
+        outputStream.SetLength(0);
+        writer = new DataWriter(outputStream);
 
         programInfo = GetChildFormatSafe<ProgramInfo>("system/info");
         sectionInfo = new RomSectionInfo {
@@ -158,7 +156,7 @@ public class NitroRom2Binary :
         // Fill size to the cartridge size
         writer.WriteUntilLength(0xFF, programInfo.CartridgeSize);
 
-        return binary;
+        return new BinaryFormat(outputStream);
     }
 
     private Node GetChildSafe(string path) =>


### PR DESCRIPTION
### Description

- Fix converter `NitroRom2Binary` when the output stream is passed in the initialization.
- Fix converter `NitroRom2Binary` when it's called several times on the same ROM node.
- Reduce memory consumption of `NitroRom2Binary` via Yarhl update.
- Add performance test for reading and writing ROMs

### Performance results

``` ini

BenchmarkDotNet=v0.13.1, OS=fedora 34
Intel Core i7-4720HQ CPU 2.60GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
.NET SDK=6.0.103
  [Host]     : .NET 6.0.3 (6.0.322.16001), X64 RyuJIT
  DefaultJob : .NET 6.0.3 (6.0.322.16001), X64 RyuJIT


```
|   Method |                 RomPath | UseKeys |         Mean |       Error |      StdDev |      Gen 0 |     Gen 1 |    Gen 2 | Allocated |
|--------- |------------------------ |-------- |-------------:|------------:|------------:|-----------:|----------:|---------:|----------:|
|  **ReadRom** | **METALMAX3_BM9JQC_00.nds** |   **False** |     **644.6 μs** |     **5.22 μs** |     **4.63 μs** |    **69.3359** |   **34.1797** |        **-** |    **363 KB** |
| WriteRom | METALMAX3_BM9JQC_00.nds |   False |  14,773.0 μs |   103.24 μs |    96.57 μs |   437.5000 |         - |        - |  1,489 KB |
|  **ReadRom** | **METALMAX3_BM9JQC_00.nds** |    **True** |   **3,703.4 μs** |    **52.41 μs** |    **46.46 μs** |   **359.3750** |  **355.4688** | **253.9063** |  **1,751 KB** |
| WriteRom | METALMAX3_BM9JQC_00.nds |    True |  16,896.0 μs |   185.35 μs |   164.31 μs |   468.7500 |         - |        - |  2,738 KB |
|  **ReadRom** |  **NINOKUNI_B2KJHF_00.nds** |   **False** |  **49,226.2 μs** |   **931.52 μs** |   **871.35 μs** |  **2181.8182** | **1000.0000** | **363.6364** | **11,478 KB** |
| WriteRom |  NINOKUNI_B2KJHF_00.nds |   False | 195,813.7 μs | 1,439.25 μs | 1,275.85 μs | 24333.3333 |         - |        - | 76,040 KB |
|  **ReadRom** |  **NINOKUNI_B2KJHF_00.nds** |    **True** |  **53,132.3 μs** |   **492.81 μs** |   **460.98 μs** |  **2200.0000** | **1100.0000** | **300.0000** | **12,762 KB** |
| WriteRom |  NINOKUNI_B2KJHF_00.nds |    True | 196,530.8 μs | 1,354.32 μs | 1,200.57 μs | 24333.3333 |         - |        - | 77,180 KB |
|  **ReadRom** |       **PSL_VPYJ2P_00.nds** |   **False** |   **2,498.6 μs** |    **25.04 μs** |    **22.19 μs** |   **183.5938** |   **89.8438** |        **-** |  **1,078 KB** |
| WriteRom |       PSL_VPYJ2P_00.nds |   False |  46,950.7 μs |   374.24 μs |   331.76 μs |  1909.0909 |         - |        - |  6,124 KB |
|  **ReadRom** |       **PSL_VPYJ2P_00.nds** |    **True** |   **5,156.0 μs** |    **69.84 μs** |    **65.33 μs** |   **226.5625** |  **109.3750** |        **-** |  **1,307 KB** |
| WriteRom |       PSL_VPYJ2P_00.nds |    True |  48,994.9 μs |   728.30 μs |   681.25 μs |  1909.0909 |         - |        - |  6,216 KB |
