### PR TITLE
:wrench: Download test resources and run tests in CI

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -15,6 +15,7 @@ on:
 
 env:
   NET_SDK: '6.0.202'
+  RESOURCES_VERSION: '1.0'
 
 jobs:
   build_main:
@@ -45,7 +46,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: resources
-          key: test-resources-v1
+          key: ${{ runner.os }}-tests-${{ env.RESOURCES_VERSION }}
 
       - name: "Build, test and stage"
         run: dotnet cake --target=Stage-Artifacts --configuration=Release --resource-uri=${{secrets.TEST_RESOURCES_URI_V1}}
@@ -93,7 +94,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: resources
-          key: test-resources-v1
+          key: ${{ runner.os }}-tests-${{ env.RESOURCES_VERSION }}
 
       # No need to stage as one job can create the binaries for all platforms
       - name: "Build and test"

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -41,8 +41,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Cache test resources
+        uses: actions/cache@v3
+        with:
+          path: resources
+          key: test-resources-v1
+
       - name: "Build, test and stage"
-        run: dotnet cake --target=Stage-Artifacts --configuration=Release --verbosity=diagnostic
+        run: dotnet cake --target=Stage-Artifacts --configuration=Release --resource-uri=${{secrets.TEST_RESOURCES_URI_V1}} --verbosity=diagnostic
 
       - name: "Publish test results"
         uses: actions/upload-artifact@v2
@@ -83,9 +89,15 @@ jobs:
       - name: "Install build tools"
         run: dotnet tool restore
 
+      - name: Cache test resources
+        uses: actions/cache@v3
+        with:
+          path: resources
+          key: test-resources-v1
+
       # No need to stage as one job can create the binaries for all platforms
       - name: "Build and test"
-        run: dotnet cake --target=BuildTest --configuration=Release --verbosity=diagnostic
+        run: dotnet cake --target=BuildTest --configuration=Release --resource-uri=${{secrets.TEST_RESOURCES_URI_V1}} --verbosity=diagnostic
 
   # Preview release on push to develop only
   # Stable release on version tag push only

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -48,7 +48,7 @@ jobs:
           key: test-resources-v1
 
       - name: "Build, test and stage"
-        run: dotnet cake --target=Stage-Artifacts --configuration=Release --resource-uri=${{secrets.TEST_RESOURCES_URI_V1}} --verbosity=diagnostic
+        run: dotnet cake --target=Stage-Artifacts --configuration=Release --resource-uri=${{secrets.TEST_RESOURCES_URI_V1}}
 
       - name: "Publish test results"
         uses: actions/upload-artifact@v2
@@ -97,7 +97,7 @@ jobs:
 
       # No need to stage as one job can create the binaries for all platforms
       - name: "Build and test"
-        run: dotnet cake --target=BuildTest --configuration=Release --resource-uri=${{secrets.TEST_RESOURCES_URI_V1}} --verbosity=diagnostic
+        run: dotnet cake --target=BuildTest --configuration=Release --resource-uri=${{secrets.TEST_RESOURCES_URI_V1}}
 
   # Preview release on push to develop only
   # Stable release on version tag push only

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ docs/_site_pdf
 # IDEs
 .vs/
 *.DotSettings.user
+
+# Test resources
+resources/

--- a/build.cake
+++ b/build.cake
@@ -1,5 +1,7 @@
 #load "nuget:?package=PleOps.Cake&version=0.7.0"
 
+string testResourceUri = Argument("resource-uri", string.Empty);
+
 Task("Define-Project")
     .Description("Fill specific project information")
     .Does<BuildInfo>(info =>
@@ -9,8 +11,37 @@ Task("Define-Project")
 
     info.PreviewNuGetFeed = "https://pkgs.dev.azure.com/SceneGate/SceneGate/_packaging/SceneGate-Preview/nuget/v3/index.json";
 
-    // It will require specific files
-    info.CoverageTarget = 0;
+    info.CoverageTarget = 85;
+});
+
+Task("Download-TestFiles")
+    .Description("Download the test resource files")
+    .IsDependeeOf("Test")
+    .Does(() =>
+{
+    string resourcesPath = MakeAbsolute(Directory("./resources")).FullPath;
+
+    if (DirectoryExists("resources")) {
+        Information("Test files already exists, skipping download.");
+        System.Environment.SetEnvironmentVariable("SCENEGATE_TEST_DIR", resourcesPath);
+        return;
+    }
+
+    if (string.IsNullOrEmpty(testResourceUri)) {
+        Information("Test resource uri is not present, skipping download.");
+        return;
+    }
+
+    var jsonInfoPath = DownloadFile(testResourceUri);
+    string jsonInfoText = System.IO.File.ReadAllText(jsonInfoPath.FullPath);
+    IEnumerable<TestResource> resources = System.Text.Json.JsonSerializer.Deserialize<IEnumerable<TestResource>>(jsonInfoText);
+
+    foreach (TestResource resource in resources) {
+        var compressedResources = DownloadFile(resource.uri);
+        Unzip(compressedResources, resource.path);
+    }
+
+    System.Environment.SetEnvironmentVariable("SCENEGATE_TEST_DIR", resourcesPath);
 });
 
 Task("Default")
@@ -18,3 +49,5 @@ Task("Default")
 
 string target = Argument("target", "Default");
 RunTarget(target);
+
+private sealed record TestResource(string uri, string path);


### PR DESCRIPTION
### Description

Add pre-step in build system to download the test resources from a secret variable. The pipeline will cache this directory.

### Example

To download the test resources use the argument `--resource-uri`:

```
dotnet cake --resource-uri http://...
```

To invalidate the cache after changing one of the resources, update the variable `RESOURCES_VERSION` in the pipeline definition. It's recommendable to create new secret variables to avoid breaking the CI of previous releases.