### PR TITLE
:wrench: Update nuget config for latest .NET 6 SDK

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -14,7 +14,7 @@ on:
       - published
 
 env:
-  NET_SDK: '6.0.202'
+  NET_SDK: '6.0.302'
   RESOURCES_VERSION: '1.0'
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -65,8 +65,20 @@ your solution file (.sln) with the following content:
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear/>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="SceneGate-Preview" value="https://pkgs.dev.azure.com/SceneGate/SceneGate/_packaging/SceneGate-Preview/nuget/v3/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="SceneGate-Preview">
+      <package pattern="Yarhl*" />
+      <package pattern="Texim*" />
+      <package pattern="SceneGate*" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>
 ```
 

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear/>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="SceneGate-Preview" value="https://pkgs.dev.azure.com/SceneGate/SceneGate/_packaging/SceneGate-Preview/nuget/v3/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="SceneGate-Preview">
+      <package pattern="Yarhl*" />
+      <package pattern="Texim" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
### Description

Starting .NET 6.0.300 the CentralPacketManagement feature requires to specify with filters the specific NuGet feed to retrieve the nuget.
Update the nuget.config file with the `packageSource` filters and update the doc.

### Example

If you have several NuGet feeds (like using SceneGate previews), update your nuget.config with:

```xml
  <packageSourceMapping>
    <packageSource key="nuget.org">
      <package pattern="*" />
    </packageSource>
    <packageSource key="SceneGate-Preview">
      <package pattern="Yarhl*" />
      <package pattern="Texim*" />
      <package pattern="SceneGate*" />
    </packageSource>
  </packageSourceMapping>
```