### PR TITLE
:sparkles: Migrate converters and examples to Yarhl 4.0 preview API

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,9 +1,9 @@
 <Project>
     <!-- Centralize dependency management -->
     <ItemGroup>
-        <PackageVersion Include="Yarhl" Version="4.0.0-preview.157" />
-        <PackageVersion Include="Yarhl.Media" Version="4.0.0-preview.157" />
-        <PackageVersion Include="Texim" Version="0.1.0-preview.129" />
+        <PackageVersion Include="Yarhl" Version="4.0.0-PullRequest0191.191" />
+        <PackageVersion Include="Yarhl.Media.Text" Version="4.0.0-PullRequest0191.191" />
+        <PackageVersion Include="Texim" Version="0.1.0-preview.156" />
         <PackageVersion Include="System.Data.HashFunction.CRC" Version="2.0.0" />
         <PackageVersion Include="Portable.BouncyCastle" Version="1.9.0" />
 

--- a/src/Ekona.Examples/Cartridge.cs
+++ b/src/Ekona.Examples/Cartridge.cs
@@ -29,10 +29,11 @@ public class Cartridge
     public void ExportGif(Node rom)
     {
         #region ExportIconGif
-        Node animated = Navigator.SearchNode(rom, "system/banner/animated");
+        NodeContainerFormat animated = Navigator.SearchNode(rom, "system/banner/animated")
+            .GetFormatAs<NodeContainerFormat>();
 
-        AnimatedFullImage animatedImage = (AnimatedFullImage)ConvertFormat.With<IconAnimation2AnimatedImage>(animated.Format);
-        using var gifData = (BinaryFormat)ConvertFormat.With<AnimatedFullImage2Gif>(animatedImage);
+        AnimatedFullImage animatedImage = new IconAnimation2AnimatedImage().Convert(animated);
+        using BinaryFormat gifData = new AnimatedFullImage2Gif().Convert(animatedImage);
 
         gifData.Stream.WriteTo("icon.gif");
         #endregion

--- a/src/Ekona.Examples/Ekona.Examples.csproj
+++ b/src/Ekona.Examples/Ekona.Examples.csproj
@@ -14,7 +14,7 @@
     <ProjectReference Include="..\Ekona\Ekona.csproj" />
 
     <PackageReference Include="Yarhl" />
-    <PackageReference Include="Yarhl.Media" />
+    <PackageReference Include="Yarhl.Media.Text" />
     <PackageReference Include="Texim" />
   </ItemGroup>
 </Project>

--- a/src/Ekona.Examples/QuickStart.cs
+++ b/src/Ekona.Examples/QuickStart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 SceneGate
+// Copyright (c) 2022 SceneGate
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -95,9 +95,11 @@ public class QuickStart
 
         // For DSi-enhanced games we can export its animated icon as GIF
         if (bannerInfo.SupportAnimatedIcon) {
-            Node animatedNode = Navigator.SearchNode(game, "system/banner/animated");
-            var animatedImage = ConvertFormat.With<IconAnimation2AnimatedImage>(animatedNode.Format);
-            using var binaryGif = (BinaryFormat)ConvertFormat.With<AnimatedFullImage2Gif>(animatedImage);
+            var animatedNode = Navigator.SearchNode(game, "system/banner/animated")
+                .GetFormatAs<NodeContainerFormat>();
+
+            var animatedImage = new IconAnimation2AnimatedImage().Convert(animatedNode);
+            using var binaryGif = new AnimatedFullImage2Gif().Convert(animatedImage);
             binaryGif.Stream.WriteTo("dump/icon.gif");
         }
         #endregion

--- a/src/Ekona.PerformanceTests/Binary2NitroRomTest.cs
+++ b/src/Ekona.PerformanceTests/Binary2NitroRomTest.cs
@@ -45,7 +45,7 @@ public class Binary2NitroRomTest
     {
         keyStore = ResourceManager.GetDsiKeyStore();
         binaryRom = new BinaryFormat(DataStreamFactory.FromFile(RomPath.Path, FileOpenMode.Read));
-        root = (NitroRom)ConvertFormat.With<Binary2NitroRom>(binaryRom);
+        root = binaryRom.ConvertWith(new Binary2NitroRom());
         outputStream = new DataStream();
     }
 
@@ -60,22 +60,20 @@ public class Binary2NitroRomTest
     [Benchmark]
     public NitroRom ReadRom()
     {
-        var converter = new Binary2NitroRom();
-        if (UseKeys) {
-            converter.Initialize(keyStore);
-        }
-
+        var converter = UseKeys ? new Binary2NitroRom() : new Binary2NitroRom(keyStore);
         return converter.Convert(binaryRom);
     }
 
     [Benchmark]
-    public void WriteRom()
+    public BinaryFormat WriteRom()
     {
-        var converter = new NitroRom2Binary();
-
         DsiKeyStore? runKeys = UseKeys ? keyStore : null;
-        converter.Initialize(new NitroRom2BinaryParams { KeyStore = runKeys, OutputStream = outputStream });
+        var parameters = new NitroRom2BinaryParams {
+            KeyStore = runKeys,
+            OutputStream = outputStream,
+        };
 
-        converter.Convert(root);
+        var converter = new NitroRom2Binary(parameters);
+        return converter.Convert(root);
     }
 }

--- a/src/Ekona.Tests/Containers/Rom/Binary2BannerTests.cs
+++ b/src/Ekona.Tests/Containers/Rom/Binary2BannerTests.cs
@@ -25,8 +25,8 @@ using FluentAssertions;
 using NUnit.Framework;
 using SceneGate.Ekona.Containers.Rom;
 using SceneGate.Ekona.Security;
+using Texim.Animations;
 using Texim.Formats;
-using Texim.Images;
 using Texim.Palettes;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
@@ -125,7 +125,10 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
             var paletteParam = new IndexedImageBitmapParams {
                 Palettes = actualIcon.GetFormatAs<IPaletteCollection>(),
             };
-            actualIcon.Invoking(n => n.TransformWith<IndexedImage2Bitmap, IndexedImageBitmapParams>(paletteParam))
+            var image2Bitmap = new IndexedImage2Bitmap();
+            image2Bitmap.Initialize(paletteParam);
+
+            actualIcon.Invoking(n => n.TransformWith(image2Bitmap))
                 .Should().NotThrow();
 
             using var expectedIcon = NodeFactory.FromFile(expectedIconPath, FileOpenMode.Read);
@@ -155,8 +158,9 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
             TestDataBase.IgnoreIfFileDoesNotExist(gifPath);
             using var expectedGif = DataStreamFactory.FromFile(gifPath, FileOpenMode.Read);
 
-            object animatedImage = ConvertFormat.With<IconAnimation2AnimatedImage>(animated.Format);
-            using var actualGif = (BinaryFormat)ConvertFormat.With<AnimatedFullImage2Gif>(animatedImage);
+            AnimatedFullImage animatedImage = animated.GetFormatAs<NodeContainerFormat>()
+                .ConvertWith(new IconAnimation2AnimatedImage());
+            using var actualGif = new AnimatedFullImage2Gif().Convert(animatedImage);
             actualGif.Stream.Compare(expectedGif).Should().BeTrue("GIF streams must be identical");
 
             string infoPath = GetAniInfoFile(bannerPath);
@@ -192,8 +196,8 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
 
             using Node node = NodeFactory.FromFile(bannerPath, FileOpenMode.Read);
 
-            var banner = (NodeContainerFormat)ConvertFormat.With<Binary2Banner>(node.Format!);
-            var generatedStream = (BinaryFormat)ConvertFormat.With<Banner2Binary>(banner);
+            var banner = node.GetFormatAs<IBinary>().ConvertWith(new Binary2Banner());
+            var generatedStream = banner.ConvertWith(new Banner2Binary());
 
             generatedStream.Stream.Length.Should().Be(node.Stream!.Length);
             generatedStream.Stream.Compare(node.Stream).Should().BeTrue();
@@ -205,9 +209,9 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
             TestDataBase.IgnoreIfFileDoesNotExist(bannerPath);
 
             using var originalStream = new BinaryFormat(DataStreamFactory.FromFile(bannerPath, FileOpenMode.Read));
-            using var originalNode = (NodeContainerFormat)ConvertFormat.With<Binary2Banner>(originalStream);
-            using var generatedStream = (BinaryFormat)ConvertFormat.With<Banner2Binary>(originalNode);
-            using var generatedNode = (NodeContainerFormat)ConvertFormat.With<Binary2Banner>(generatedStream);
+            using NodeContainerFormat originalNode = originalStream.ConvertWith(new Binary2Banner());
+            using BinaryFormat generatedStream = originalNode.ConvertWith(new Banner2Binary());
+            using NodeContainerFormat generatedNode = generatedStream.ConvertWith(new Binary2Banner());
 
             generatedNode.Should().BeEquivalentTo(originalNode, opts => opts.IgnoringCyclicReferences());
         }

--- a/src/Ekona.Tests/Containers/Rom/Binary2RomHeaderTests.cs
+++ b/src/Ekona.Tests/Containers/Rom/Binary2RomHeaderTests.cs
@@ -120,8 +120,8 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
 
             using Node node = NodeFactory.FromFile(headerPath, FileOpenMode.Read);
 
-            var header = (RomHeader)ConvertFormat.With<Binary2RomHeader>(node.Format!);
-            var generatedStream = (BinaryFormat)ConvertFormat.With<RomHeader2Binary>(header);
+            RomHeader header = node.GetFormatAs<IBinary>().ConvertWith(new Binary2RomHeader());
+            BinaryFormat generatedStream = header.ConvertWith(new RomHeader2Binary());
 
             var originalStream = new DataStream(node.Stream!, 0, header.SectionInfo.HeaderSize);
             generatedStream.Stream.Length.Should().Be(originalStream.Length);
@@ -135,9 +135,9 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
 
             using Node node = NodeFactory.FromFile(headerPath, FileOpenMode.Read);
 
-            var originalHeader = (RomHeader)ConvertFormat.With<Binary2RomHeader>(node.Format!);
-            using var generatedStream = (BinaryFormat)ConvertFormat.With<RomHeader2Binary>(originalHeader);
-            var generatedHeader = (RomHeader)ConvertFormat.With<Binary2RomHeader>(generatedStream);
+            RomHeader originalHeader = node.GetFormatAs<IBinary>().ConvertWith(new Binary2RomHeader());
+            using BinaryFormat generatedStream = originalHeader.ConvertWith(new RomHeader2Binary());
+            RomHeader generatedHeader = generatedStream.ConvertWith(new Binary2RomHeader());
 
             generatedHeader.Should().BeEquivalentTo(
                 originalHeader,

--- a/src/Ekona/Containers/Rom/Binary2NitroRom.cs
+++ b/src/Ekona/Containers/Rom/Binary2NitroRom.cs
@@ -33,12 +33,12 @@ namespace SceneGate.Ekona.Containers.Rom
     /// <summary>
     /// Converter for binary formats into a NitroRom container.
     /// </summary>
-    public class Binary2NitroRom : IConverter<IBinary, NitroRom>, IInitializer<DsiKeyStore>
+    public class Binary2NitroRom : IConverter<IBinary, NitroRom>
     {
         private const int SecureAreaLength = 16 * 1024;
         private static readonly FileAddressOffsetComparer FileAddressComparer = new FileAddressOffsetComparer();
 
-        private DsiKeyStore keyStore;
+        private readonly DsiKeyStore keyStore;
 
         private DataReader reader;
         private NitroRom rom;
@@ -47,12 +47,19 @@ namespace SceneGate.Ekona.Containers.Rom
         private List<FileAddress> addressesByOffset;
 
         /// <summary>
-        /// Initializes the converter with the key store to validate signatures.
+        /// Initializes a new instance of the <see cref="Binary2NitroRom"/> class.
         /// </summary>
-        /// <param name="parameters">The key store.</param>
-        public void Initialize(DsiKeyStore parameters)
+        public Binary2NitroRom()
         {
-            keyStore = parameters;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Binary2NitroRom"/> class.
+        /// </summary>
+        /// <param name="keys">Keys for hashes validation.</param>
+        public Binary2NitroRom(DsiKeyStore keys)
+        {
+            keyStore = keys;
         }
 
         /// <summary>
@@ -62,8 +69,7 @@ namespace SceneGate.Ekona.Containers.Rom
         /// <returns>The new node container.</returns>
         public NitroRom Convert(IBinary source)
         {
-            if (source == null)
-                throw new ArgumentNullException(nameof(source));
+            ArgumentNullException.ThrowIfNull(source);
 
             source.Stream.Position = 0;
             reader = new DataReader(source.Stream);
@@ -89,7 +95,7 @@ namespace SceneGate.Ekona.Containers.Rom
             reader.Stream.Seek(Binary2RomHeader.HeaderSizeOffset, SeekOrigin.Begin);
             int headerSize = reader.ReadInt32();
             using var binaryHeader = new BinaryFormat(reader.Stream, 0, headerSize);
-            header = (RomHeader)ConvertFormat.With<Binary2RomHeader>(binaryHeader);
+            header = binaryHeader.ConvertWith(new Binary2RomHeader());
 
             rom.System.Children["info"].ChangeFormat(header.ProgramInfo);
 

--- a/src/Ekona/Containers/Rom/Binary2RomHeader.cs
+++ b/src/Ekona/Containers/Rom/Binary2RomHeader.cs
@@ -27,31 +27,36 @@ namespace SceneGate.Ekona.Containers.Rom
     /// <summary>
     /// Converter for binary ROM header into an object.
     /// </summary>
-    public class Binary2RomHeader :
-        IInitializer<DsiKeyStore>,
-        IConverter<IBinary, RomHeader>
+    public class Binary2RomHeader : IConverter<IBinary, RomHeader>
     {
         private const int SecureAreaLength = 16 * 1024;
-        private DsiKeyStore keyStore;
+        private readonly DsiKeyStore keyStore;
 
         /// <summary>
-        /// Gets the offset in the header containing the header size value.
+        /// Initializes a new instance of the <see cref="Binary2RomHeader"/> class.
         /// </summary>
-        public static int HeaderSizeOffset => 0x84;
+        public Binary2RomHeader()
+        {
+        }
 
         /// <summary>
-        /// Initialize the converter with the key store to enable additional features.
+        /// Initializes a new instance of the <see cref="Binary2RomHeader"/> class.
         /// </summary>
         /// <remarks>
         /// The key store is used to verify a special token and set the value of `DisableSecureArea`.
         /// Otherwise, it will always be `false`. The required key is `BlowfishDsKey`.
         /// </remarks>
-        /// <param name="parameters">The converter parameters.</param>
+        /// <param name="keyStore">The converter parameters.</param>
         /// <exception cref="ArgumentNullException">The argument is null.</exception>
-        public void Initialize(DsiKeyStore parameters)
+        public Binary2RomHeader(DsiKeyStore keyStore)
         {
-            keyStore = parameters ?? throw new ArgumentNullException(nameof(parameters));
+            this.keyStore = keyStore ?? throw new ArgumentNullException(nameof(keyStore));
         }
+
+        /// <summary>
+        /// Gets the offset in the header containing the header size value.
+        /// </summary>
+        public static int HeaderSizeOffset => 0x84;
 
         /// <summary>
         /// Convert a binary format into a ROM header object.

--- a/src/Ekona/Containers/Rom/RomHeader2Binary.cs
+++ b/src/Ekona/Containers/Rom/RomHeader2Binary.cs
@@ -27,24 +27,29 @@ namespace SceneGate.Ekona.Containers.Rom;
 /// <summary>
 /// Converter for ROM header object into binary stream (serialization).
 /// </summary>
-public class RomHeader2Binary :
-    IInitializer<DsiKeyStore>,
-    IConverter<RomHeader, BinaryFormat>
+public class RomHeader2Binary : IConverter<RomHeader, BinaryFormat>
 {
-    private DsiKeyStore keyStore;
+    private readonly DsiKeyStore keyStore;
 
     /// <summary>
-    /// Initialize the converter with the key store to enable additional features.
+    /// Initializes a new instance of the <see cref="RomHeader2Binary"/> class.
+    /// </summary>
+    public RomHeader2Binary()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RomHeader2Binary"/> class.
     /// </summary>
     /// <remarks>
     /// The key store is used to generate a special token if `DisableSecureArea` is `true`.
     /// Otherwise, it will always write 0. The required key is `BlowfishDsKey`.
     /// </remarks>
-    /// <param name="parameters">The converter parameters.</param>
+    /// <param name="keyStore">The converter parameters.</param>
     /// <exception cref="ArgumentNullException">The argument is null.</exception>
-    public void Initialize(DsiKeyStore parameters)
+    public RomHeader2Binary(DsiKeyStore keyStore)
     {
-        keyStore = parameters ?? throw new ArgumentNullException(nameof(parameters));
+        this.keyStore = keyStore ?? throw new ArgumentNullException(nameof(keyStore));
     }
 
     /// <summary>


### PR DESCRIPTION
### Description

Upgrade to the preview package of Yarhl with the new API for converters.

### Example

Use the converter constructors instead of the `Initialize` method to pass parameters.
See https://github.com/SceneGate/Yarhl/pull/191 for more details.