### PR TITLE
✨ Migrate to Yarhl v4.0 converters and support .NET 8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@
 _Ekona_ is a library part of the [_SceneGate_](https://github.com/SceneGate)
 framework that provides support for **DS and DSi file formats.**
 
-The library supports .NET 6.0 and above on Linux, Window and MacOS.
-
 ## Supported formats
 
 - :video_game: DS cartridge:
@@ -64,7 +62,7 @@ items.Stream.WriteTo("dump/Items.dat");
 ## Usage
 
 The project provides the following .NET libraries (NuGet packages in nuget.org).
-The libraries only support the latest .NET LTS version: **.NET 6.0**.
+The libraries works on supported versions of .NET: 6.0 and 8.0.
 
 - [![SceneGate.Ekona](https://img.shields.io/nuget/v/SceneGate.Ekona?label=SceneGate.Ekona&logo=nuget)](https://www.nuget.org/packages/SceneGate.Ekona)
   - `SceneGate.Ekona.Containers.Rom`: DS and DSi cartridge (ROM) format.

--- a/docs/articles/dev/tutorial.md
+++ b/docs/articles/dev/tutorial.md
@@ -6,7 +6,7 @@ support for DS and DSi file formats.
 ## Usage
 
 The project provides the following .NET libraries (NuGet packages in nuget.org).
-The libraries only support the latest .NET LTS version: **.NET 6.0**.
+The libraries works on supported versions of .NET: 6.0 and 8.0.
 
 - [![SceneGate.Ekona](https://img.shields.io/nuget/v/SceneGate.Ekona?label=SceneGate.Ekona&logo=nuget)](https://www.nuget.org/packages/SceneGate.Ekona)
   - `SceneGate.Ekona.Containers.Rom`: DS and DSi cartridge (ROM) format.

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@ items.Stream.WriteTo("dump/Items.dat");
 ## Usage
 
 The project provides the following .NET libraries (NuGet packages in nuget.org).
-The libraries only support the latest .NET LTS version: **.NET 6.0**.
+The libraries works on supported versions of .NET: 6.0 and 8.0.
 
 - [![SceneGate.Ekona](https://img.shields.io/nuget/v/SceneGate.Ekona?label=SceneGate.Ekona&logo=nuget)](https://www.nuget.org/packages/SceneGate.Ekona)
   - `SceneGate.Ekona.Containers.Rom`: DS and DSi cartridge (ROM) format.

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,20 +1,18 @@
 <Project>
-    <!-- Centralize dependency management -->
-    <ItemGroup>
-        <PackageVersion Include="Yarhl" Version="4.0.0-PullRequest0191.191" />
-        <PackageVersion Include="Yarhl.Media.Text" Version="4.0.0-PullRequest0191.191" />
-        <PackageVersion Include="Texim" Version="0.1.0-preview.156" />
-        <PackageVersion Include="System.Data.HashFunction.CRC" Version="2.0.0" />
-        <PackageVersion Include="Portable.BouncyCastle" Version="1.9.0" />
-
-        <PackageVersion Include="YamlDotNet" Version="11.2.1" />
-        <PackageVersion Include="FluentAssertions" Version="6.6.0" />
-        <PackageVersion Include="nunit" Version="3.13.3" />
-        <PackageVersion Include="NUnit3TestAdapter" Version="4.2.1" />
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.1.0"/>
-        <PackageVersion Include="coverlet.collector" Version="3.1.2" />
-        <PackageVersion Include="BenchmarkDotNet" Version="0.13.1" />
-
-        <PackageVersion Include="SonarAnalyzer.CSharp" Version="8.37.0.45539" />
-    </ItemGroup>
+  <!-- Centralize dependency management -->
+  <ItemGroup>
+    <PackageVersion Include="Yarhl" Version="4.0.0-preview.283" />
+    <PackageVersion Include="Yarhl.Media.Text" Version="4.0.0-preview.283" />
+    <PackageVersion Include="Texim" Version="0.1.0-preview.207" />
+    <PackageVersion Include="System.Data.HashFunction.CRC" Version="2.0.0" />
+    <PackageVersion Include="Portable.BouncyCastle" Version="1.9.0" />
+    <PackageVersion Include="YamlDotNet" Version="13.7.1" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
+    <PackageVersion Include="nunit" Version="4.0.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.13.10" />
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.14.0.81108" />
+  </ItemGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,9 +1,9 @@
 <Project>
     <!-- Centralize dependency management -->
     <ItemGroup>
-        <PackageVersion Include="Yarhl" Version="4.0.0-preview.157" />
-        <PackageVersion Include="Yarhl.Media" Version="4.0.0-preview.157" />
-        <PackageVersion Include="Texim" Version="0.1.0-preview.129" />
+        <PackageVersion Include="Yarhl" Version="4.0.0-PullRequest0191.191" />
+        <PackageVersion Include="Yarhl.Media.Text" Version="4.0.0-PullRequest0191.191" />
+        <PackageVersion Include="Texim" Version="0.1.0-preview.156" />
         <PackageVersion Include="System.Data.HashFunction.CRC" Version="2.0.0" />
         <PackageVersion Include="Portable.BouncyCastle" Version="1.9.0" />
 

--- a/src/Ekona.Examples/Cartridge.cs
+++ b/src/Ekona.Examples/Cartridge.cs
@@ -29,10 +29,11 @@ public class Cartridge
     public void ExportGif(Node rom)
     {
         #region ExportIconGif
-        Node animated = Navigator.SearchNode(rom, "system/banner/animated");
+        NodeContainerFormat animated = Navigator.SearchNode(rom, "system/banner/animated")
+            .GetFormatAs<NodeContainerFormat>();
 
-        AnimatedFullImage animatedImage = (AnimatedFullImage)ConvertFormat.With<IconAnimation2AnimatedImage>(animated.Format);
-        using var gifData = (BinaryFormat)ConvertFormat.With<AnimatedFullImage2Gif>(animatedImage);
+        AnimatedFullImage animatedImage = new IconAnimation2AnimatedImage().Convert(animated);
+        using BinaryFormat gifData = new AnimatedFullImage2Gif().Convert(animatedImage);
 
         gifData.Stream.WriteTo("icon.gif");
         #endregion

--- a/src/Ekona.Examples/Ekona.Examples.csproj
+++ b/src/Ekona.Examples/Ekona.Examples.csproj
@@ -16,7 +16,7 @@
     <ProjectReference Include="..\Ekona\Ekona.csproj" />
 
     <PackageReference Include="Yarhl" />
-    <PackageReference Include="Yarhl.Media" />
+    <PackageReference Include="Yarhl.Media.Text" />
     <PackageReference Include="Texim" />
   </ItemGroup>
 </Project>

--- a/src/Ekona.Examples/Ekona.Examples.csproj
+++ b/src/Ekona.Examples/Ekona.Examples.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>SceneGate.Ekona.Examples</AssemblyName>
     <Description>Examples for the documentation.</Description>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <RootNamespace>SceneGate.Ekona.Examples</RootNamespace>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/src/Ekona.Examples/QuickStart.cs
+++ b/src/Ekona.Examples/QuickStart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 SceneGate
+// Copyright (c) 2022 SceneGate
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -95,9 +95,11 @@ public class QuickStart
 
         // For DSi-enhanced games we can export its animated icon as GIF
         if (bannerInfo.SupportAnimatedIcon) {
-            Node animatedNode = Navigator.SearchNode(game, "system/banner/animated");
-            var animatedImage = ConvertFormat.With<IconAnimation2AnimatedImage>(animatedNode.Format);
-            using var binaryGif = (BinaryFormat)ConvertFormat.With<AnimatedFullImage2Gif>(animatedImage);
+            var animatedNode = Navigator.SearchNode(game, "system/banner/animated")
+                .GetFormatAs<NodeContainerFormat>();
+
+            var animatedImage = new IconAnimation2AnimatedImage().Convert(animatedNode);
+            using var binaryGif = new AnimatedFullImage2Gif().Convert(animatedImage);
             binaryGif.Stream.WriteTo("dump/icon.gif");
         }
         #endregion

--- a/src/Ekona.Examples/QuickStart.cs
+++ b/src/Ekona.Examples/QuickStart.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 SceneGate
+﻿// Copyright (c) 2022 SceneGate
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -87,8 +87,8 @@ public class QuickStart
             .GetFormatAs<IndexedPaletteImage>();
 
         // Using Texim converters, create a PNG image
-        IndexedImage2Bitmap bitmapConverter = new IndexedImage2Bitmap();
-        bitmapConverter.Initialize(new IndexedImageBitmapParams { Palettes = icon });
+        var converterParameters = new IndexedImageBitmapParams { Palettes = icon };
+        var bitmapConverter = new IndexedImage2Bitmap(converterParameters);
 
         using BinaryFormat binaryPng = bitmapConverter.Convert(icon);
         binaryPng.Stream.WriteTo("dump/icon.png");

--- a/src/Ekona.PerformanceTests/Binary2NitroRomTest.cs
+++ b/src/Ekona.PerformanceTests/Binary2NitroRomTest.cs
@@ -45,7 +45,7 @@ public class Binary2NitroRomTest
     {
         keyStore = ResourceManager.GetDsiKeyStore();
         binaryRom = new BinaryFormat(DataStreamFactory.FromFile(RomPath.Path, FileOpenMode.Read));
-        root = (NitroRom)ConvertFormat.With<Binary2NitroRom>(binaryRom);
+        root = binaryRom.ConvertWith(new Binary2NitroRom());
         outputStream = new DataStream();
     }
 
@@ -60,22 +60,20 @@ public class Binary2NitroRomTest
     [Benchmark]
     public NitroRom ReadRom()
     {
-        var converter = new Binary2NitroRom();
-        if (UseKeys) {
-            converter.Initialize(keyStore);
-        }
-
+        var converter = UseKeys ? new Binary2NitroRom() : new Binary2NitroRom(keyStore);
         return converter.Convert(binaryRom);
     }
 
     [Benchmark]
-    public void WriteRom()
+    public BinaryFormat WriteRom()
     {
-        var converter = new NitroRom2Binary();
-
         DsiKeyStore? runKeys = UseKeys ? keyStore : null;
-        converter.Initialize(new NitroRom2BinaryParams { KeyStore = runKeys, OutputStream = outputStream });
+        var parameters = new NitroRom2BinaryParams {
+            KeyStore = runKeys,
+            OutputStream = outputStream,
+        };
 
-        converter.Convert(root);
+        var converter = new NitroRom2Binary(parameters);
+        return converter.Convert(root);
     }
 }

--- a/src/Ekona.PerformanceTests/Ekona.PerformanceTests.csproj
+++ b/src/Ekona.PerformanceTests/Ekona.PerformanceTests.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Ekona.PerformanceTests</AssemblyName>
     <Description>Tests for Ekona.</Description>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <RootNamespace>SceneGate.Ekona.PerformanceTests</RootNamespace>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/src/Ekona.Tests/Containers/Rom/Binary2BannerTests.cs
+++ b/src/Ekona.Tests/Containers/Rom/Binary2BannerTests.cs
@@ -1,4 +1,4 @@
-// Copyright(c) 2021 SceneGate
+﻿// Copyright(c) 2021 SceneGate
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -125,8 +125,7 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
             var paletteParam = new IndexedImageBitmapParams {
                 Palettes = actualIcon.GetFormatAs<IPaletteCollection>(),
             };
-            var image2Bitmap = new IndexedImage2Bitmap();
-            image2Bitmap.Initialize(paletteParam);
+            var image2Bitmap = new IndexedImage2Bitmap(paletteParam);
 
             actualIcon.Invoking(n => n.TransformWith(image2Bitmap))
                 .Should().NotThrow();

--- a/src/Ekona.Tests/Containers/Rom/Binary2BannerTests.cs
+++ b/src/Ekona.Tests/Containers/Rom/Binary2BannerTests.cs
@@ -25,8 +25,8 @@ using FluentAssertions;
 using NUnit.Framework;
 using SceneGate.Ekona.Containers.Rom;
 using SceneGate.Ekona.Security;
+using Texim.Animations;
 using Texim.Formats;
-using Texim.Images;
 using Texim.Palettes;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
@@ -125,7 +125,10 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
             var paletteParam = new IndexedImageBitmapParams {
                 Palettes = actualIcon.GetFormatAs<IPaletteCollection>(),
             };
-            actualIcon.Invoking(n => n.TransformWith<IndexedImage2Bitmap, IndexedImageBitmapParams>(paletteParam))
+            var image2Bitmap = new IndexedImage2Bitmap();
+            image2Bitmap.Initialize(paletteParam);
+
+            actualIcon.Invoking(n => n.TransformWith(image2Bitmap))
                 .Should().NotThrow();
 
             using var expectedIcon = NodeFactory.FromFile(expectedIconPath, FileOpenMode.Read);
@@ -155,8 +158,9 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
             TestDataBase.IgnoreIfFileDoesNotExist(gifPath);
             using var expectedGif = DataStreamFactory.FromFile(gifPath, FileOpenMode.Read);
 
-            object animatedImage = ConvertFormat.With<IconAnimation2AnimatedImage>(animated.Format);
-            using var actualGif = (BinaryFormat)ConvertFormat.With<AnimatedFullImage2Gif>(animatedImage);
+            AnimatedFullImage animatedImage = animated.GetFormatAs<NodeContainerFormat>()
+                .ConvertWith(new IconAnimation2AnimatedImage());
+            using var actualGif = new AnimatedFullImage2Gif().Convert(animatedImage);
             actualGif.Stream.Compare(expectedGif).Should().BeTrue("GIF streams must be identical");
 
             string infoPath = GetAniInfoFile(bannerPath);
@@ -192,8 +196,8 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
 
             using Node node = NodeFactory.FromFile(bannerPath, FileOpenMode.Read);
 
-            var banner = (NodeContainerFormat)ConvertFormat.With<Binary2Banner>(node.Format!);
-            var generatedStream = (BinaryFormat)ConvertFormat.With<Banner2Binary>(banner);
+            var banner = node.GetFormatAs<IBinary>().ConvertWith(new Binary2Banner());
+            var generatedStream = banner.ConvertWith(new Banner2Binary());
 
             generatedStream.Stream.Length.Should().Be(node.Stream!.Length);
             generatedStream.Stream.Compare(node.Stream).Should().BeTrue();
@@ -205,9 +209,9 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
             TestDataBase.IgnoreIfFileDoesNotExist(bannerPath);
 
             using var originalStream = new BinaryFormat(DataStreamFactory.FromFile(bannerPath, FileOpenMode.Read));
-            using var originalNode = (NodeContainerFormat)ConvertFormat.With<Binary2Banner>(originalStream);
-            using var generatedStream = (BinaryFormat)ConvertFormat.With<Banner2Binary>(originalNode);
-            using var generatedNode = (NodeContainerFormat)ConvertFormat.With<Binary2Banner>(generatedStream);
+            using NodeContainerFormat originalNode = originalStream.ConvertWith(new Binary2Banner());
+            using BinaryFormat generatedStream = originalNode.ConvertWith(new Banner2Binary());
+            using NodeContainerFormat generatedNode = generatedStream.ConvertWith(new Binary2Banner());
 
             generatedNode.Should().BeEquivalentTo(originalNode, opts => opts.IgnoringCyclicReferences());
         }

--- a/src/Ekona.Tests/Containers/Rom/Binary2RomHeaderTests.cs
+++ b/src/Ekona.Tests/Containers/Rom/Binary2RomHeaderTests.cs
@@ -120,8 +120,8 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
 
             using Node node = NodeFactory.FromFile(headerPath, FileOpenMode.Read);
 
-            var header = (RomHeader)ConvertFormat.With<Binary2RomHeader>(node.Format!);
-            var generatedStream = (BinaryFormat)ConvertFormat.With<RomHeader2Binary>(header);
+            RomHeader header = node.GetFormatAs<IBinary>().ConvertWith(new Binary2RomHeader());
+            BinaryFormat generatedStream = header.ConvertWith(new RomHeader2Binary());
 
             var originalStream = new DataStream(node.Stream!, 0, header.SectionInfo.HeaderSize);
             generatedStream.Stream.Length.Should().Be(originalStream.Length);
@@ -135,9 +135,9 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
 
             using Node node = NodeFactory.FromFile(headerPath, FileOpenMode.Read);
 
-            var originalHeader = (RomHeader)ConvertFormat.With<Binary2RomHeader>(node.Format!);
-            using var generatedStream = (BinaryFormat)ConvertFormat.With<RomHeader2Binary>(originalHeader);
-            var generatedHeader = (RomHeader)ConvertFormat.With<Binary2RomHeader>(generatedStream);
+            RomHeader originalHeader = node.GetFormatAs<IBinary>().ConvertWith(new Binary2RomHeader());
+            using BinaryFormat generatedStream = originalHeader.ConvertWith(new RomHeader2Binary());
+            RomHeader generatedHeader = generatedStream.ConvertWith(new Binary2RomHeader());
 
             generatedHeader.Should().BeEquivalentTo(
                 originalHeader,

--- a/src/Ekona.Tests/Ekona.Tests.csproj
+++ b/src/Ekona.Tests/Ekona.Tests.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>SceneGate.Ekona.Tests</AssemblyName>
     <Description>Tests for Ekona.</Description>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
 
     <RootNamespace>SceneGate.Ekona.Tests</RootNamespace>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/src/Ekona.sln
+++ b/src/Ekona.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31313.79
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34322.80
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ekona", "Ekona\Ekona.csproj", "{2E92C69F-6D59-4430-A017-E4A6E8B916E4}"
 EndProject
@@ -9,15 +9,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ekona.Tests", "Ekona.Tests\
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{105F9DFE-4DDF-436A-BF87-106E3676759D}"
 	ProjectSection(SolutionItems) = preProject
-		.editorconfig = .editorconfig
-		..\build.cake = ..\build.cake
 		Directory.Build.props = Directory.Build.props
 		Directory.Packages.props = Directory.Packages.props
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ekona.PerformanceTests", "Ekona.PerformanceTests\Ekona.PerformanceTests.csproj", "{5808F29C-C802-4728-99A5-E1F299178002}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ekona.PerformanceTests", "Ekona.PerformanceTests\Ekona.PerformanceTests.csproj", "{5808F29C-C802-4728-99A5-E1F299178002}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ekona.Examples", "Ekona.Examples\Ekona.Examples.csproj", "{E1BC44DB-CAA3-4C74-8A5A-7D536A53E09F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ekona.Examples", "Ekona.Examples\Ekona.Examples.csproj", "{E1BC44DB-CAA3-4C74-8A5A-7D536A53E09F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Ekona/Containers/Rom/Binary2NitroRom.cs
+++ b/src/Ekona/Containers/Rom/Binary2NitroRom.cs
@@ -1,4 +1,4 @@
-// Copyright(c) 2021 SceneGate
+﻿// Copyright(c) 2021 SceneGate
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -191,10 +191,10 @@ namespace SceneGate.Ekona.Containers.Rom
 
             int area;
             uint modcryptLength;
-            if (kinds.Any(k => header.ProgramInfo.DsiInfo.ModcryptArea1Target == k)) {
+            if (Array.Exists(kinds, k => header.ProgramInfo.DsiInfo.ModcryptArea1Target == k)) {
                 area = 1;
                 modcryptLength = header.SectionInfo.ModcryptArea1Length;
-            } else if (kinds.Any(k => header.ProgramInfo.DsiInfo.ModcryptArea2Target == k)) {
+            } else if (Array.Exists(kinds, k => header.ProgramInfo.DsiInfo.ModcryptArea2Target == k)) {
                 area = 2;
                 modcryptLength = header.SectionInfo.ModcryptArea2Length;
             } else {

--- a/src/Ekona/Containers/Rom/Binary2NitroRom.cs
+++ b/src/Ekona/Containers/Rom/Binary2NitroRom.cs
@@ -33,12 +33,12 @@ namespace SceneGate.Ekona.Containers.Rom
     /// <summary>
     /// Converter for binary formats into a NitroRom container.
     /// </summary>
-    public class Binary2NitroRom : IConverter<IBinary, NitroRom>, IInitializer<DsiKeyStore>
+    public class Binary2NitroRom : IConverter<IBinary, NitroRom>
     {
         private const int SecureAreaLength = 16 * 1024;
         private static readonly FileAddressOffsetComparer FileAddressComparer = new FileAddressOffsetComparer();
 
-        private DsiKeyStore keyStore;
+        private readonly DsiKeyStore keyStore;
 
         private DataReader reader;
         private NitroRom rom;
@@ -47,12 +47,19 @@ namespace SceneGate.Ekona.Containers.Rom
         private List<FileAddress> addressesByOffset;
 
         /// <summary>
-        /// Initializes the converter with the key store to validate signatures.
+        /// Initializes a new instance of the <see cref="Binary2NitroRom"/> class.
         /// </summary>
-        /// <param name="parameters">The key store.</param>
-        public void Initialize(DsiKeyStore parameters)
+        public Binary2NitroRom()
         {
-            keyStore = parameters;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Binary2NitroRom"/> class.
+        /// </summary>
+        /// <param name="keys">Keys for hashes validation.</param>
+        public Binary2NitroRom(DsiKeyStore keys)
+        {
+            keyStore = keys;
         }
 
         /// <summary>
@@ -62,8 +69,7 @@ namespace SceneGate.Ekona.Containers.Rom
         /// <returns>The new node container.</returns>
         public NitroRom Convert(IBinary source)
         {
-            if (source == null)
-                throw new ArgumentNullException(nameof(source));
+            ArgumentNullException.ThrowIfNull(source);
 
             source.Stream.Position = 0;
             reader = new DataReader(source.Stream);
@@ -89,7 +95,7 @@ namespace SceneGate.Ekona.Containers.Rom
             reader.Stream.Seek(Binary2RomHeader.HeaderSizeOffset, SeekOrigin.Begin);
             int headerSize = reader.ReadInt32();
             using var binaryHeader = new BinaryFormat(reader.Stream, 0, headerSize);
-            header = (RomHeader)ConvertFormat.With<Binary2RomHeader>(binaryHeader);
+            header = binaryHeader.ConvertWith(new Binary2RomHeader());
 
             rom.System.Children["info"].ChangeFormat(header.ProgramInfo);
 

--- a/src/Ekona/Containers/Rom/Binary2RomHeader.cs
+++ b/src/Ekona/Containers/Rom/Binary2RomHeader.cs
@@ -27,31 +27,36 @@ namespace SceneGate.Ekona.Containers.Rom
     /// <summary>
     /// Converter for binary ROM header into an object.
     /// </summary>
-    public class Binary2RomHeader :
-        IInitializer<DsiKeyStore>,
-        IConverter<IBinary, RomHeader>
+    public class Binary2RomHeader : IConverter<IBinary, RomHeader>
     {
         private const int SecureAreaLength = 16 * 1024;
-        private DsiKeyStore keyStore;
+        private readonly DsiKeyStore keyStore;
 
         /// <summary>
-        /// Gets the offset in the header containing the header size value.
+        /// Initializes a new instance of the <see cref="Binary2RomHeader"/> class.
         /// </summary>
-        public static int HeaderSizeOffset => 0x84;
+        public Binary2RomHeader()
+        {
+        }
 
         /// <summary>
-        /// Initialize the converter with the key store to enable additional features.
+        /// Initializes a new instance of the <see cref="Binary2RomHeader"/> class.
         /// </summary>
         /// <remarks>
         /// The key store is used to verify a special token and set the value of `DisableSecureArea`.
         /// Otherwise, it will always be `false`. The required key is `BlowfishDsKey`.
         /// </remarks>
-        /// <param name="parameters">The converter parameters.</param>
+        /// <param name="keyStore">The converter parameters.</param>
         /// <exception cref="ArgumentNullException">The argument is null.</exception>
-        public void Initialize(DsiKeyStore parameters)
+        public Binary2RomHeader(DsiKeyStore keyStore)
         {
-            keyStore = parameters ?? throw new ArgumentNullException(nameof(parameters));
+            this.keyStore = keyStore ?? throw new ArgumentNullException(nameof(keyStore));
         }
+
+        /// <summary>
+        /// Gets the offset in the header containing the header size value.
+        /// </summary>
+        public static int HeaderSizeOffset => 0x84;
 
         /// <summary>
         /// Convert a binary format into a ROM header object.

--- a/src/Ekona/Containers/Rom/IconAnimation2AnimatedImage.cs
+++ b/src/Ekona/Containers/Rom/IconAnimation2AnimatedImage.cs
@@ -1,4 +1,4 @@
-// Copyright(c) 2022 SceneGate
+﻿// Copyright(c) 2022 SceneGate
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -61,7 +61,6 @@ namespace SceneGate.Ekona.Containers.Rom
             var animatedImage = new AnimatedFullImage();
             animatedImage.Loops = 0; // infinite
 
-            var fullImageConverter = new Indexed2FullImage();
             int width = bitmaps[0].Width;
             int height = bitmaps[0].Height;
 
@@ -76,7 +75,7 @@ namespace SceneGate.Ekona.Containers.Rom
                 }
 
                 var frameIndexed = new IndexedImage(width, height, framePixels.ToArray());
-                fullImageConverter.Initialize(palette.Palettes[frameInfo.PaletteIndex]);
+                var fullImageConverter = new Indexed2FullImage(palette.Palettes[frameInfo.PaletteIndex]);
                 FullImage frameImage = fullImageConverter.Convert(frameIndexed);
 
                 var frame = new FullImageFrame {

--- a/src/Ekona/Containers/Rom/RomHeader2Binary.cs
+++ b/src/Ekona/Containers/Rom/RomHeader2Binary.cs
@@ -27,24 +27,29 @@ namespace SceneGate.Ekona.Containers.Rom;
 /// <summary>
 /// Converter for ROM header object into binary stream (serialization).
 /// </summary>
-public class RomHeader2Binary :
-    IInitializer<DsiKeyStore>,
-    IConverter<RomHeader, BinaryFormat>
+public class RomHeader2Binary : IConverter<RomHeader, BinaryFormat>
 {
-    private DsiKeyStore keyStore;
+    private readonly DsiKeyStore keyStore;
 
     /// <summary>
-    /// Initialize the converter with the key store to enable additional features.
+    /// Initializes a new instance of the <see cref="RomHeader2Binary"/> class.
+    /// </summary>
+    public RomHeader2Binary()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RomHeader2Binary"/> class.
     /// </summary>
     /// <remarks>
     /// The key store is used to generate a special token if `DisableSecureArea` is `true`.
     /// Otherwise, it will always write 0. The required key is `BlowfishDsKey`.
     /// </remarks>
-    /// <param name="parameters">The converter parameters.</param>
+    /// <param name="keyStore">The converter parameters.</param>
     /// <exception cref="ArgumentNullException">The argument is null.</exception>
-    public void Initialize(DsiKeyStore parameters)
+    public RomHeader2Binary(DsiKeyStore keyStore)
     {
-        keyStore = parameters ?? throw new ArgumentNullException(nameof(parameters));
+        this.keyStore = keyStore ?? throw new ArgumentNullException(nameof(keyStore));
     }
 
     /// <summary>

--- a/src/Ekona/Ekona.csproj
+++ b/src/Ekona/Ekona.csproj
@@ -5,7 +5,7 @@
     <Description>Library for NDS file formats.</Description>
     <IsPackable>true</IsPackable>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
 
     <RootNamespace>SceneGate.Ekona</RootNamespace>
     <Nullable>disable</Nullable>

--- a/src/Ekona/Security/HashInfo.cs
+++ b/src/Ekona/Security/HashInfo.cs
@@ -1,4 +1,4 @@
-// Copyright(c) 2022 SceneGate
+﻿// Copyright(c) 2022 SceneGate
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -17,6 +17,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
+using System;
 using System.Linq;
 
 namespace SceneGate.Ekona.Security;
@@ -63,7 +64,7 @@ public class HashInfo
     /// <summary>
     /// Gets a value indicating whether the hash is null.
     /// </summary>
-    public bool IsNull => Hash.All(x => x == 0);
+    public bool IsNull => Array.TrueForAll(Hash, x => x == 0);
 
     /// <summary>
     /// Gets or sets the status of the hash.

--- a/src/Ekona/Security/TwilightHMacGenerator.cs
+++ b/src/Ekona/Security/TwilightHMacGenerator.cs
@@ -1,4 +1,4 @@
-// Copyright(c) 2022 SceneGate
+﻿// Copyright(c) 2022 SceneGate
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -252,9 +252,8 @@ public class TwilightHMacGenerator
         uint blockLength = sectionInfo.DigestBlockSectorCount * HashLength;
         byte[] buffer = new byte[blockLength];
 
-        bool result = true;
         int numBlockHashes = (int)sectionInfo.DigestBlockHashtableLength / HashLength;
-        for (int i = 0; i < numBlockHashes && result; i++) {
+        for (int i = 0; i < numBlockHashes; i++) {
             romStream.Position = sectionInfo.DigestSectorHashtableOffset + (i * blockLength);
             romStream.Read(buffer);
             yield return generator.ComputeHash(buffer);
@@ -356,7 +355,7 @@ public class TwilightHMacGenerator
             } else if (twilightBlockIdx < twilightMaxBlocks) {
                 hashOffset = sectionInfo.DigestTwilightOffset + (twilightBlockIdx * sectionInfo.DigestSectorSize);
                 twilightBlockIdx++;
-            } else if (expectedHash.All(x => x == 0)) {
+            } else if (Array.TrueForAll(expectedHash, x => x == 0)) {
                 // Because the length includes padding, we don't know if we reach to the end of hashes.
                 yield break;
             } else {

--- a/src/Ekona/Security/TwilightHMacGenerator.cs
+++ b/src/Ekona/Security/TwilightHMacGenerator.cs
@@ -384,9 +384,7 @@ public class TwilightHMacGenerator
 
     private static HMAC CreateGenerator(byte[] key)
     {
-        var hmac = HMAC.Create("HMACSHA1");
-        hmac.Key = key;
-        return hmac;
+        return new HMACSHA1(key);
     }
 
     private static byte[] Generate(byte[] key, Stream stream) => Generate(key, stream, 0, stream.Length);


### PR DESCRIPTION
Upgrade to the latest preview of Yarhl 4.0 and Texim. Migrate to the new converters API with constructors.
Also add support for .NET 8.0.

## Quality check list

- [x] Related code has been tested automatically or manually
- [x] Related documentation is updated
- [x] I acknowledge I have read and filled this checklist and accept the
      [developer certificate of origin](https://developercertificate.org/)

## Acceptance criteria

- Libraries uses latest preview of Yarhl and Texim
- Libraries compile and pass tests with .NET 8.0

## Follow-up work

None