### PR TITLE
🐛 Fix potential crash encrypting with Modcrypt, invalid header hash generation and corruption of Modcrypt after arm9 changes

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -15,7 +15,7 @@ jobs:
     name: "Build"
     uses: ./.github/workflows/build.yml
     with:
-      dotnet_version: '8.0.101'
+      dotnet_version: '8.0.204'
     secrets:
       test_resources: ${{ secrets.TEST_RESOURCES_URI_V1 }}
 
@@ -27,7 +27,7 @@ jobs:
     needs: build
     uses: ./.github/workflows/deploy.yml
     with:
-      dotnet_version: '8.0.101'
+      dotnet_version: '8.0.204'
       azure_nuget_feed: 'https://pkgs.dev.azure.com/SceneGate/SceneGate/_packaging/SceneGate-Preview/nuget/v3/index.json'
     secrets:
       nuget_preview_token: "az" # Dummy values as we use Azure DevOps onlyg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,11 @@ jobs:
         with:
           dotnet-version: ${{ inputs.dotnet_version }}
 
+      - name: "Setup .NET 6 SDK"
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 6.0.421
+
       - if: ${{ env.test_resources != '' }}
         name: "Build and run FULL tests"
         run: dotnet run --project build/orchestrator -- --resource-uri=${{ env.test_resources }} --target=Default --dotnet-configuration=Release

--- a/src/Ekona/Containers/Rom/NitroRom2Binary.cs
+++ b/src/Ekona/Containers/Rom/NitroRom2Binary.cs
@@ -1,4 +1,4 @@
-// Copyright(c) 2022 SceneGate
+﻿// Copyright(c) 2022 SceneGate
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -137,6 +137,9 @@ public class NitroRom2Binary : IConverter<NodeContainerFormat, BinaryFormat>
 
         sectionInfo.RomSize = (uint)writer.Stream.Length;
 
+        // ARM9 won't change anymore, so we can encrypt it for hash generation
+        using DataStream encryptedArm9 = GetEncryptedArm9();
+
         if (programInfo.UnitCode != DeviceUnitKind.DS) {
             // Padding to start twilight section
             writer.WritePadding(0xFF, 0x100000);
@@ -147,7 +150,7 @@ public class NitroRom2Binary : IConverter<NodeContainerFormat, BinaryFormat>
             sectionInfo.DigestTwilightOffset = sectionInfo.Arm9iOffset;
 
             // Needs to happen before the modcrypt encryption.
-            WriteActualDigest();
+            WriteActualDigest(encryptedArm9);
 
             var modcrypt1 = EncryptModcrypt(programInfo.DsiInfo.ModcryptArea1Target, 1);
             var modcrypt2 = EncryptModcrypt(programInfo.DsiInfo.ModcryptArea2Target, 2);
@@ -157,7 +160,7 @@ public class NitroRom2Binary : IConverter<NodeContainerFormat, BinaryFormat>
             sectionInfo.DsiRomLength = (uint)writer.Stream.Length;
         }
 
-        WriteHeader();
+        WriteHeader(encryptedArm9);
 
         // Fill size to the cartridge size
         writer.WriteUntilLength(0xFF, programInfo.CartridgeSize);
@@ -177,7 +180,7 @@ public class NitroRom2Binary : IConverter<NodeContainerFormat, BinaryFormat>
            $"Expected {typeof(T).FullName}, got: {child.Format?.GetType().FullName}");
     }
 
-    private void WriteHeader()
+    private void WriteHeader(DataStream encryptedArm9)
     {
         var header = new RomHeader {
             ProgramInfo = programInfo,
@@ -194,13 +197,20 @@ public class NitroRom2Binary : IConverter<NodeContainerFormat, BinaryFormat>
             header.CopyrightLogo = new byte[156];
         }
 
+        // Generate the header secure area CRC
+        // It's inside the 0x160 bytes of the header, those bytes are later hashed by other HMACs
+        // so we need to get them valid in the pre-header writing.
+        var crcGenerator = new NitroCrcGenerator();
+        byte[] secureAreaCrc = crcGenerator.GenerateCrc16(encryptedArm9, 0, SecureAreaLength);
+        programInfo.ChecksumSecureArea.ChangeHash(secureAreaCrc);
+
         // We need to write a first time the header because we need some of the data
         // for the signatures.
         using BinaryFormat initialHeader = header.ConvertWith(new RomHeader2Binary());
         writer.Stream.Position = 0;
         initialHeader.Stream.WriteTo(writer.Stream);
 
-        GenerateSignatures();
+        GenerateSignatures(encryptedArm9);
 
         // Re-write with the good signatures.
         // We don't calculate the header length but we expect it's preset.
@@ -210,26 +220,27 @@ public class NitroRom2Binary : IConverter<NodeContainerFormat, BinaryFormat>
         binaryHeader.Stream.WriteTo(writer.Stream);
     }
 
-    private void GenerateSignatures()
+    private DataStream GetEncryptedArm9()
+    {
+        var key1Encryption = new NitroKey1Encryption(programInfo.GameCode, keyStore);
+
+        // Get ARM9 encrypted (or encrypt it) since it's used for several CRC / hashes
+        // We can't use anymore the node system as the arm9 may have been patched
+        // with the code parameters such us its compressed length
+        using var arm9 = new DataStream(writer.Stream, sectionInfo.Arm9Offset, sectionInfo.Arm9Size);
+        return key1Encryption.HasEncryptedArm9(arm9)
+            ? new DataStream(arm9)
+            : key1Encryption.EncryptArm9(arm9);
+    }
+
+    private void GenerateSignatures(DataStream encryptedArm9)
     {
         if (keyStore is null) {
             return;
         }
 
         bool isDsi = programInfo.UnitCode != DeviceUnitKind.DS;
-        var key1Encryption = new NitroKey1Encryption(programInfo.GameCode, keyStore);
         var hashGenerator = new TwilightHMacGenerator(keyStore);
-        var crcGenerator = new NitroCrcGenerator();
-
-        // Get ARM9 encrypted (or encrypt it) since it's used for several CRC / hashes
-        DataStream arm9 = GetChildFormatSafe<IBinary>("system/arm9").Stream;
-        using DataStream encryptedArm9 = key1Encryption.HasEncryptedArm9(arm9)
-            ? new DataStream(arm9)
-            : key1Encryption.EncryptArm9(arm9);
-
-        // Header secure area CRC
-        byte[] secureAreaCrc = crcGenerator.GenerateCrc16(encryptedArm9, 0, SecureAreaLength);
-        programInfo.ChecksumSecureArea.ChangeHash(secureAreaCrc);
 
         // HMAC for phase 1 and 2 of DS games
         bool generatePhase12 = programInfo.ProgramFeatures.HasFlag(DsiRomFeatures.NitroProgramSigned);
@@ -631,20 +642,13 @@ public class NitroRom2Binary : IConverter<NodeContainerFormat, BinaryFormat>
         writer.WritePadding(0xFF, PaddingSize);
     }
 
-    private void WriteActualDigest()
+    private void WriteActualDigest(DataStream encryptedArm9)
     {
         if (keyStore?.HMacKeyDSiGames is not { Length: > 0 }) {
             return;
         }
 
-        var key1Encryption = new NitroKey1Encryption(programInfo.GameCode, keyStore);
         var hashGenerator = new TwilightHMacGenerator(keyStore);
-
-        DataStream arm9 = GetChildFormatSafe<IBinary>("system/arm9").Stream;
-        using DataStream encryptedArm9 = key1Encryption.HasEncryptedArm9(arm9)
-            ? new DataStream(arm9)
-            : key1Encryption.EncryptArm9(arm9);
-
         hashGenerator.WriteDigestSectionContent(writer.Stream, encryptedArm9, root.Children["system"], sectionInfo);
         hashGenerator.WriteDigestBlock(writer.Stream, sectionInfo);
         programInfo.DsiInfo.DigestHashesStatus = HashStatus.Generated;

--- a/src/Ekona/Security/Modcrypt.cs
+++ b/src/Ekona/Security/Modcrypt.cs
@@ -162,12 +162,13 @@ public class Modcrypt
         byte[] keyY = programInfo.DsiInfo.Arm9iMac.Hash[0..16];
 
         // Key = ((Key_X XOR Key_Y) + scrambler) ROL 42
+        const ulong Mask42Bits = 0x3FF_FFFFFFFF;
         byte[] scrambler = { 0x79, 0x3E, 0x4F, 0x1A, 0x5F, 0x0F, 0x68, 0x2A, 0x58, 0x02, 0x59, 0x29, 0x4E, 0xFB, 0xFE, 0xFF };
         var bigX = new BigInteger(keyX, isUnsigned: true);
         var bigY = new BigInteger(keyY, isUnsigned: true);
         var bigScrambler = new BigInteger(scrambler, isUnsigned: true);
         var keyNum = ((bigX ^ bigY) + bigScrambler) << 42;
-        keyNum |= keyNum >> 128; // move to overflow 128-bits into lower part (ROL 42)
+        keyNum = keyNum | ((keyNum >> 128) & Mask42Bits); // move to overflow 128-bits into lower part (ROL 42)
         byte[] key = keyNum.ToByteArray(isUnsigned: true)[0..16]; // Get first 128-bits (like an AND)
 
         // Reverse everything

--- a/src/Ekona/Security/Modcrypt.cs
+++ b/src/Ekona/Security/Modcrypt.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 SceneGate
+﻿// Copyright (c) 2022 SceneGate
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -163,12 +163,12 @@ public class Modcrypt
 
         // Key = ((Key_X XOR Key_Y) + scrambler) ROL 42
         byte[] scrambler = { 0x79, 0x3E, 0x4F, 0x1A, 0x5F, 0x0F, 0x68, 0x2A, 0x58, 0x02, 0x59, 0x29, 0x4E, 0xFB, 0xFE, 0xFF };
-        var bigX = new BigInteger(keyX);
-        var bigY = new BigInteger(keyY);
-        var bigScrambler = new BigInteger(scrambler);
+        var bigX = new BigInteger(keyX, isUnsigned: true);
+        var bigY = new BigInteger(keyY, isUnsigned: true);
+        var bigScrambler = new BigInteger(scrambler, isUnsigned: true);
         var keyNum = ((bigX ^ bigY) + bigScrambler) << 42;
         keyNum |= keyNum >> 128; // move to overflow 128-bits into lower part (ROL 42)
-        byte[] key = keyNum.ToByteArray()[0..16]; // Get first 128-bits (like an AND)
+        byte[] key = keyNum.ToByteArray(isUnsigned: true)[0..16]; // Get first 128-bits (like an AND)
 
         // Reverse everything
         Array.Reverse(iv);


### PR DESCRIPTION
Fix several bugs related to Modcrypt (d)encryption and ROM header hash generation, especially after changes on the arm9 and/or its code parameters (such as compression length):

- Potential unhandled exception, calculating the key for Modcrypt (d)encryption for retail software. This may happen during ROM reading or writing.
  - The reason is that by default `BigInteger` are signed values and after the bitwise OR operation, the sign may be affected changing a 22-bytes length number to a 6-bytes length number.
- Fix generation of arm9 secure area when its code parameters changes. The hash was calculated with arm9 content before patching the code parameter values such as file compressed length.
- Fix program HMAC generation: it was calculated with an old value of arm9 secure are hash
- Fix corruption of modcrypt content: the content was encrypted with an old arm9 secure hash which is part of the key.

Also fix the build by installing .NET 6 SDK and bumping .NET 8 SDK.

## Quality check list

- [x] Related code has been tested automatically or manually: tested with the problematic software and updated tests
- [x] Related documentation is updated
- [x] I acknowledge I have read and filled this checklist and accept the
      [developer certificate of origin](https://developercertificate.org/)

## Acceptance criteria

The Modcrypt key generation does not fail.
Every hash of the encrypted content is valid after changing the arm9 content.

## Follow-up work

None

## Example

N/A
