### PR TITLE
:sparkles: Add API to verify all the hashes and signature

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,13 +6,13 @@
     <PackageVersion Include="Texim" Version="0.1.0-preview.210" />
     <PackageVersion Include="System.Data.HashFunction.CRC" Version="2.0.0" />
     <PackageVersion Include="Portable.BouncyCastle" Version="1.9.0" />
-    <PackageVersion Include="YamlDotNet" Version="15.1.1" />
+    <PackageVersion Include="YamlDotNet" Version="15.1.4" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
-    <PackageVersion Include="nunit" Version="4.0.1" />
+    <PackageVersion Include="nunit" Version="4.1.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.12" />
-    <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.19.0.84025" />
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.25.0.90414" />
   </ItemGroup>
 </Project>

--- a/src/Ekona.Tests/Containers/Rom/Binary2NitroRomTests.cs
+++ b/src/Ekona.Tests/Containers/Rom/Binary2NitroRomTests.cs
@@ -133,6 +133,9 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
 
                 programInfo.DsiInfo.DigestHashesStatus.Should().Be(HashStatus.Valid);
             }
+
+            programInfo.HasValidHashes().Should().BeTrue();
+            programInfo.HasValidSignature().Should().BeTrue();
         }
 
         [TestCaseSource(nameof(GetFiles))]
@@ -379,6 +382,9 @@ namespace SceneGate.Ekona.Tests.Containers.Rom
                     programInfo.DsiInfo.DigestHashesStatus.Should().Be(HashStatus.Valid);
                 }
             }
+
+            programInfo.HasValidHashes().Should().BeTrue();
+            programInfo.HasValidSignature().Should().Be(!isDsi);
         }
     }
 }

--- a/src/Ekona.Tests/Containers/Rom/ProgramInfoTests.cs
+++ b/src/Ekona.Tests/Containers/Rom/ProgramInfoTests.cs
@@ -1,0 +1,198 @@
+﻿namespace SceneGate.Ekona.Tests.Containers.Rom;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SceneGate.Ekona.Containers.Rom;
+using SceneGate.Ekona.Security;
+
+[TestFixture]
+internal class ProgramInfoTests
+{
+    [Test]
+    public void HasValidHashesTrueIfNull()
+    {
+        var info = new ProgramInfo();
+
+        Assert.That(info.HasValidHashes(), Is.True);
+    }
+
+    [Test]
+    public void HasValidHashesTrueIfGenerated()
+    {
+        var info = new ProgramInfo();
+        _ = CreateDsHashes(info, HashStatus.Generated);
+
+        Assert.That(info.HasValidHashes(), Is.True);
+    }
+
+    [Test]
+    public void HasValidHashesThrowsIfNotValidated()
+    {
+        var info = new ProgramInfo();
+        _ = CreateDsHashes(info, HashStatus.NotValidated);
+
+        Assert.That(() => info.HasValidHashes(), Throws.InvalidOperationException);
+    }
+
+    [Test]
+    public void HasValidHashesFalseIfAnyInvalid()
+    {
+        var info = new ProgramInfo();
+        HashInfo[] hashInfos = CreateDsHashes(info, HashStatus.Invalid);
+
+        foreach (HashInfo hashInfo in hashInfos) {
+            Assert.That(info.HasValidHashes(), Is.False);
+            hashInfo.Status = HashStatus.Valid;
+        }
+
+        Assert.That(info.HasValidHashes(), Is.True);
+    }
+
+    [Test]
+    public void HasValidHashesTrueIfAllValid()
+    {
+        var info = new ProgramInfo();
+        _ = CreateDsHashes(info, HashStatus.Valid);
+
+        Assert.That(info.HasValidHashes(), Is.True);
+    }
+
+    [Test]
+    public void HasValidHashesDsi()
+    {
+        var info = new ProgramInfo();
+        HashInfo[] hashInfos = CreateDsiHashes(info, HashStatus.Invalid);
+
+        foreach (HashInfo hashInfo in hashInfos) {
+            Assert.That(info.HasValidHashes(), Is.False);
+            hashInfo.Status = HashStatus.Valid;
+        }
+
+        Assert.That(info.HasValidHashes(), Is.False);
+
+        info.DsiInfo.DigestHashesStatus = HashStatus.Valid;
+        Assert.That(info.HasValidHashes(), Is.True);
+    }
+
+    [Test]
+    public void HasValidHashesDsExtended()
+    {
+        var info = new ProgramInfo();
+        HashInfo[] hashInfos = CreateDsExtendedHashes(info, HashStatus.Invalid);
+
+        foreach (HashInfo hashInfo in hashInfos) {
+            Assert.That(info.HasValidHashes(), Is.False);
+            hashInfo.Status = HashStatus.Valid;
+        }
+
+        Assert.That(info.HasValidHashes(), Is.True);
+    }
+
+    [Test]
+    public void HasSignatureForDsIsTrue()
+    {
+        var info = new ProgramInfo();
+        info.UnitCode = DeviceUnitKind.DS;
+
+        Assert.That(info.HasValidSignature(), Is.True);
+
+        info.Signature = CreateHashInfo(HashStatus.Invalid);
+        Assert.That(info.HasValidSignature(), Is.True);
+    }
+
+    [Test]
+    public void HasSignatureForDsi()
+    {
+        var info = new ProgramInfo();
+        info.UnitCode = DeviceUnitKind.DSiExclusive;
+
+        // null signature
+        Assert.That(info.HasValidSignature(), Is.True);
+
+        info.Signature = CreateHashInfo(HashStatus.Generated);
+        Assert.That(info.HasValidSignature(), Is.True);
+
+        info.Signature.Status = HashStatus.Invalid;
+        Assert.That(info.HasValidSignature(), Is.False);
+
+        info.Signature.Status = HashStatus.Valid;
+        Assert.That(info.HasValidSignature(), Is.True);
+
+        info.Signature.Status = HashStatus.NotValidated;
+        Assert.That(() => info.HasValidSignature(), Throws.InvalidOperationException);
+    }
+
+    private static HashInfo[] CreateDsHashes(ProgramInfo info, HashStatus status)
+    {
+        info.UnitCode = DeviceUnitKind.DS;
+
+#pragma warning disable S1121 // cool syntax for tests
+        var hashInfos = new List<HashInfo> {
+            (info.ChecksumHeader = CreateHashInfo(status)),
+            (info.ChecksumLogo = CreateHashInfo(status)),
+            (info.ChecksumSecureArea = CreateHashInfo(status)),
+        };
+#pragma warning restore S1121
+
+        return hashInfos.ToArray();
+    }
+
+    private static HashInfo[] CreateDsExtendedHashes(ProgramInfo info, HashStatus status)
+    {
+        info.UnitCode = DeviceUnitKind.DS;
+
+        info.ProgramFeatures = DsiRomFeatures.NitroProgramSigned | DsiRomFeatures.NitroBannerSigned;
+
+#pragma warning disable S1121 // cool syntax for tests
+        var hashInfos = new List<HashInfo> {
+            (info.ChecksumHeader = CreateHashInfo(status)),
+            (info.ChecksumLogo = CreateHashInfo(status)),
+            (info.ChecksumSecureArea = CreateHashInfo(status)),
+
+            (info.BannerMac = CreateHashInfo(status)),
+
+            (info.NitroProgramMac = CreateHashInfo(status)),
+            (info.NitroOverlaysMac = CreateHashInfo(status)),
+        };
+#pragma warning restore S1121
+
+        return hashInfos.ToArray();
+    }
+
+    private static HashInfo[] CreateDsiHashes(ProgramInfo info, HashStatus status)
+    {
+        info.UnitCode = DeviceUnitKind.DSiExclusive;
+        info.DsiInfo ??= new DsiProgramInfo();
+
+        info.DsiInfo.DigestHashesStatus = status;
+
+#pragma warning disable S1121 // cool syntax for tests
+        var hashInfos = new List<HashInfo> {
+            (info.ChecksumHeader = CreateHashInfo(status)),
+            (info.ChecksumLogo = CreateHashInfo(status)),
+            (info.ChecksumSecureArea = CreateHashInfo(status)),
+
+            (info.BannerMac = CreateHashInfo(status)),
+
+            (info.DsiInfo.Arm9SecureMac = CreateHashInfo(status)),
+            (info.DsiInfo.Arm7Mac = CreateHashInfo(status)),
+            (info.DsiInfo.DigestMain = CreateHashInfo(status)),
+            (info.DsiInfo.Arm9iMac = CreateHashInfo(status)),
+            (info.DsiInfo.Arm7iMac = CreateHashInfo(status)),
+            (info.DsiInfo.Arm9Mac = CreateHashInfo(status)),
+        };
+#pragma warning restore S1121
+
+        return hashInfos.ToArray();
+    }
+
+    private static HashInfo CreateHashInfo(HashStatus status)
+    {
+        return new HashInfo("TestAlgo", new byte[] { 0x42 }) {
+            Status = status,
+        };
+    }
+}

--- a/src/Ekona.Tests/Ekona.Tests.csproj
+++ b/src/Ekona.Tests/Ekona.Tests.csproj
@@ -19,7 +19,10 @@
     <PackageReference Include="nunit" />
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Add a couple of methods to verify the status of every hash in the ROM header. They take into a account if the hash is present or not, depending on the console (DS / DSi).
It also verifies the signature only on DSi software.

Also bump dependencies.

## Quality check list

- [x] Related code has been tested automatically or manually
- [x] Related documentation is updated
- [x] I acknowledge I have read and filled this checklist and accept the
      [developer certificate of origin](https://developercertificate.org/)

## Acceptance criteria

One API to verify the validity of a ROM

## Follow-up work

None

## Example

```csharp
bool hasValidHashes = programInfo.HasValidHashes();
bool hasValidSignature = programInfo.HasValidSignature();
```